### PR TITLE
Datapipes for MetNet National forecast

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,11 +19,11 @@ dependencies:
   - geopandas
   - h5netcdf
   - pip:
-    - einops
-    - pathy
-    - git+https://github.com/SheffieldSolar/PV_Live-API
-    - pyaml_env
-    - nowcasting_datamodel
-    - gitpython
-    - tqdm
-    - bottleneck
+      - einops
+      - pathy
+      - git+https://github.com/SheffieldSolar/PV_Live-API
+      - pyaml_env
+      - nowcasting_datamodel
+      - gitpython
+      - tqdm
+      - bottleneck

--- a/environment.yml
+++ b/environment.yml
@@ -18,12 +18,12 @@ dependencies:
   - pyresample
   - geopandas
   - h5netcdf
-pip:
-  - einops
-  - pathy
-  - git+https://github.com/SheffieldSolar/PV_Live-API
-  - pyaml_env
-  - nowcasting_datamodel
-  - gitpython
-  - tqdm
-  - bottleneck
+  - pip:
+    - einops
+    - pathy
+    - git+https://github.com/SheffieldSolar/PV_Live-API
+    - pyaml_env
+    - nowcasting_datamodel
+    - gitpython
+    - tqdm
+    - bottleneck

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - pyresample
   - geopandas
   - h5netcdf
+  - scipy
   - pip:
       - einops
       - pathy

--- a/ocf_datapipes/load/gsp/gsp_national.py
+++ b/ocf_datapipes/load/gsp/gsp_national.py
@@ -38,7 +38,7 @@ class OpenGSPNationalIterDataPipe(IterDataPipe):
         # Load GSP generation xr.Dataset:
         gsp_pv_power_mw_ds = xr.load_dataset(self.gsp_pv_power_zarr_path, engine="zarr")
 
-        # onty select nationa data
+        # only select national data
         logger.debug("Selecting National data only")
         gsp_pv_power_mw_ds = gsp_pv_power_mw_ds.sel(gsp_id=0)
 

--- a/ocf_datapipes/transform/xarray/__init__.py
+++ b/ocf_datapipes/transform/xarray/__init__.py
@@ -23,5 +23,5 @@ from .get_contiguous_time_periods import (
 )
 from .metnet_preprocessor import PreProcessMetNetIterDataPipe as PreProcessMetNet
 from .normalize import NormalizeIterDataPipe as Normalize
-from .reproject_topographic_data import ReprojectTopographyIterDataPipe as ReprojectTopography
 from .pv.create_pv_image import CreatePVImageIterDataPipe as CreatePVImage
+from .reproject_topographic_data import ReprojectTopographyIterDataPipe as ReprojectTopography

--- a/ocf_datapipes/transform/xarray/__init__.py
+++ b/ocf_datapipes/transform/xarray/__init__.py
@@ -24,3 +24,4 @@ from .get_contiguous_time_periods import (
 from .metnet_preprocessor import PreProcessMetNetIterDataPipe as PreProcessMetNet
 from .normalize import NormalizeIterDataPipe as Normalize
 from .reproject_topographic_data import ReprojectTopographyIterDataPipe as ReprojectTopography
+from .pv.create_pv_image import CreatePVImageIterDataPipe as CreatePVImage

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -67,14 +67,20 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
             contexts = []
 
             for xr_data in xr_datas:
-                xr_context: xr.Dataset = _get_spatial_crop(xr_data, location=location,
-                                               roi_width_meters=self.context_width,
-                                               roi_height_meters=self.context_height,
-                                               dim_name="data")
-                xr_center: xr.Dataset = _get_spatial_crop(xr_data, location=location,
-                                               roi_width_meters=self.center_width,
-                                               roi_height_meters=self.center_height,
-                                               dim_name="data")
+                xr_context: xr.Dataset = _get_spatial_crop(
+                    xr_data,
+                    location=location,
+                    roi_width_meters=self.context_width,
+                    roi_height_meters=self.context_height,
+                    dim_name="data",
+                )
+                xr_center: xr.Dataset = _get_spatial_crop(
+                    xr_data,
+                    location=location,
+                    roi_width_meters=self.center_width,
+                    roi_height_meters=self.center_height,
+                    dim_name="data",
+                )
                 # TODO Resample here before stacking
                 xr_center = xr_center.coarsen(y=3).mean().coarsen(x=3).mean()
                 xr_context = xr_context.coarsen(y=3).mean().coarsen(x=3).mean()

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -3,9 +3,10 @@ from typing import List
 
 import numpy as np
 import xarray as xr
+from scipy import signal
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe, Zipper
-from scipy import signal
+
 
 @functional_datapipe("preprocess_metnet")
 class PreProcessMetNetIterDataPipe(IterDataPipe):
@@ -83,8 +84,12 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
                     dim_name="data",
                 )
                 # Resamples to the same number of pixels for both center and contexts
-                xr_center = _resample_to_pixel_size(xr_center, self.output_height_pixels, self.output_width_pixels)
-                xr_context = _resample_to_pixel_size(xr_context, self.output_height_pixels, self.output_width_pixels)
+                xr_center = _resample_to_pixel_size(
+                    xr_center, self.output_height_pixels, self.output_width_pixels
+                )
+                xr_context = _resample_to_pixel_size(
+                    xr_context, self.output_height_pixels, self.output_width_pixels
+                )
                 centers.append(xr_center)
                 contexts.append(xr_context)
             stacked_data = np.stack([*centers, *contexts], dim=-1)
@@ -110,6 +115,7 @@ def _get_spatial_crop(xr_data, location, roi_height_meters, roi_width_meters, di
 
     selected = xr_data.isel({dim_name: id_mask})
     return selected
+
 
 def _resample_to_pixel_size(xr_data, height_pixels, width_pixels):
     x_coords = xr_data["x"].values

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -67,23 +67,19 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
             contexts = []
 
             for xr_data in xr_datas:
-                xr_context = _get_spatial_crop(
-                    xr_data,
-                    location=location,
-                    roi_width_meters=self.context_width,
-                    roi_height_meters=self.context_height,
-                    dim_name="data",
-                )
-                xr_center = _get_spatial_crop(
-                    xr_data,
-                    location=location,
-                    roi_width_meters=self.center_width,
-                    roi_height_meters=self.center_height,
-                    dim_name="data",
-                )
+                xr_context: xr.Dataset = _get_spatial_crop(xr_data, location=location,
+                                               roi_width_meters=self.context_width,
+                                               roi_height_meters=self.context_height,
+                                               dim_name="data")
+                xr_center: xr.Dataset = _get_spatial_crop(xr_data, location=location,
+                                               roi_width_meters=self.center_width,
+                                               roi_height_meters=self.center_height,
+                                               dim_name="data")
+                # TODO Resample here before stacking
+                xr_center = xr_center.coarsen(y=3).mean().coarsen(x=3).mean()
+                xr_context = xr_context.coarsen(y=3).mean().coarsen(x=3).mean()
                 centers.append(xr_center)
                 contexts.append(xr_context)
-            # TODO Resample here before stacking
             stacked_data = np.stack([*centers, *contexts], dim=-1)
             yield stacked_data
 

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -166,9 +166,7 @@ def _get_spatial_crop(xr_data, location, roi_height_meters: int, roi_width_meter
         left, bottom = _osgb_to_geostationary(xx=left, yy=bottom)
         right, top = _osgb_to_geostationary(xx=right, yy=top)
         x_mask = (left <= xr_data.x) & (xr_data.x <= right)
-        y_mask = (xr_data.y <= top) & (  # Y is flipped
-                bottom <= xr_data.y
-        )
+        y_mask = (xr_data.y <= top) & (bottom <= xr_data.y)  # Y is flipped
         selected = xr_data.isel(x=x_mask, y=y_mask)
     else:
         # Select data in the region of interest:

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -1,10 +1,11 @@
 """Preprocessing for MetNet-type inputs"""
 from typing import List
 
+import numpy as np
+import xarray as xr
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe, Zipper
-import xarray as xr
-import numpy as np
+
 
 @functional_datapipe("preprocess_metnet")
 class PreProcessMetNetIterDataPipe(IterDataPipe):
@@ -19,7 +20,7 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
         center_width: float,
         center_height: float,
         output_height_pixels: int,
-        output_width_pixels: int
+        output_width_pixels: int,
     ):
         """
 
@@ -66,14 +67,20 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
             contexts = []
 
             for xr_data in xr_datas:
-                xr_context = _get_spatial_crop(xr_data, location=location,
-                                               roi_width_meters=self.context_width,
-                                               roi_height_meters=self.context_height,
-                                               dim_name="data")
-                xr_center = _get_spatial_crop(xr_data, location=location,
-                                               roi_width_meters=self.center_width,
-                                               roi_height_meters=self.center_height,
-                                               dim_name="data")
+                xr_context = _get_spatial_crop(
+                    xr_data,
+                    location=location,
+                    roi_width_meters=self.context_width,
+                    roi_height_meters=self.context_height,
+                    dim_name="data",
+                )
+                xr_center = _get_spatial_crop(
+                    xr_data,
+                    location=location,
+                    roi_width_meters=self.center_width,
+                    roi_height_meters=self.center_height,
+                    dim_name="data",
+                )
                 centers.append(xr_center)
                 contexts.append(xr_context)
             # TODO Resample here before stacking
@@ -92,10 +99,10 @@ def _get_spatial_crop(xr_data, location, roi_height_meters, roi_width_meters, di
     top = location.y + half_height
     # Select data in the region of interest:
     id_mask = (
-            (left <= xr_data.x_osgb)
-            & (xr_data.x_osgb <= right)
-            & (xr_data.y_osgb <= top)
-            & (bottom <= xr_data.y_osgb)
+        (left <= xr_data.x_osgb)
+        & (xr_data.x_osgb <= right)
+        & (xr_data.y_osgb <= top)
+        & (bottom <= xr_data.y_osgb)
     )
 
     selected = xr_data.isel({dim_name: id_mask})

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -111,23 +111,27 @@ def _get_spatial_crop(xr_data, location, roi_height_meters: int, roi_width_meter
         _osgb_to_geostationary = load_geostationary_area_definition_and_transform_osgb(xr_data)
         left, bottom = _osgb_to_geostationary(xx=left, yy=bottom)
         right, top = _osgb_to_geostationary(xx=right, yy=top)
-        # Select data in the region of interest:
-        id_mask = (
+        x_mask = (
                 (left <= xr_data.x_geostationary)
                 & (xr_data.x_geostationary <= right)
-                & (xr_data.y_geostationary <= bottom) # Y is flipped in satellite
-                & (top <= xr_data.y_geostationary) # Y is flipped in satellite
         )
+        y_mask = (
+                (xr_data.y_geostationary <= bottom)
+                & (top <= xr_data.y_geostationary)
+        )
+        selected = xr_data.isel(x_geostationary=x_mask, y_geostationary=y_mask)
     else:
         # Select data in the region of interest:
-        id_mask = (
-            (left <= xr_data.x_osgb)
-            & (xr_data.x_osgb <= right)
-            & (xr_data.y_osgb <= top)
-            & (bottom <= xr_data.y_osgb)
+        x_mask = (
+                (left <= xr_data.x_osgb)
+                & (xr_data.x_osgb <= right)
         )
+        y_mask = (
+                (xr_data.y_osgb <= top)
+                & (bottom <= xr_data.y_osgb)
+        )
+        selected = xr_data.isel(x_osgb=x_mask, y_osgb=y_mask)
 
-    selected = xr_data.isel({dim_name: id_mask})
     return selected
 
 

--- a/ocf_datapipes/transform/xarray/metnet_preprocessor.py
+++ b/ocf_datapipes/transform/xarray/metnet_preprocessor.py
@@ -13,10 +13,10 @@ class PreProcessMetNetIterDataPipe(IterDataPipe):
         self,
         source_datapipes: List[IterDataPipe],
         location_datapipe: IterDataPipe,
-        context_width,
-        context_height,
-        center_width,
-        center_height,
+        context_width: float,
+        context_height: float,
+        center_width: float,
+        center_height: float,
     ):
         """
 

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -53,9 +53,6 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                 ),
                 dtype=np.float32,
             )
-            # Coordinates should be in order for the image, so just need to do the search sorted thing to get the index to add the PV output to
-            # Once all the outputs are added, then normalize? Could also normalize PV first, then normalize the normalized PV data
-            # In either case have to iterate through all PV systems in example
             for pv_system_id in pv_systems_xr["pv_system_id"]:
                 pv_system = pv_systems_xr.sel(pv_system_id=pv_system_id)
                 if "geostationary" in self.x_dim:
@@ -74,7 +71,6 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                     print("Failing on Y")
                     continue
                 if "geostationary" in self.x_dim:
-                    # Get the index into x and y nearest to x_center_geostationary and y_center_geostationary:
                     x_idx = np.searchsorted(image_xr[self.x_dim].values, pv_x) - 1
                     # y_geostationary is in descending order:
                     y_idx = len(image_xr[self.y_dim]) - (

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -30,7 +30,7 @@ class CreatePVImage(IterDataPipe):
         for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
             # Create empty image to use for the PV Systems, assumes image has x and y coordinates
             pv_image = np.zeros(
-                (len(pv_systems_xr["time"]), len(image_xr["x"]), len(image_xr["y"])),
+                (len(pv_systems_xr["time"]), len(image_xr["x_osgb"]), len(image_xr["y_osgb"])),
                 dtype=np.float32,
             )
             # Coordinates should be in order for the image, so just need to do the search sorted thing to get the index to add the PV output to
@@ -38,12 +38,12 @@ class CreatePVImage(IterDataPipe):
             # In either case have to iterate through all PV systems in example
             for pv_system in pv_systems_xr["pv_system_id"]:
                 # Quick check as search sorted doesn't give an error if it is not in the range
-                if pv_system["x"] < image_xr["x"][0] or pv_system["x"] > image_xr["x"][-1]:
+                if pv_system["x_osgb"] < image_xr["x_osgb"][0] or pv_system["x_osgb"] > image_xr["x_osgb"][-1]:
                     continue
-                if pv_system["y"] < image_xr["y"][0] or pv_system["y"] > image_xr["y"][-1]:
+                if pv_system["y_osgb"] < image_xr["y_osgb"][0] or pv_system["y_osgb"] > image_xr["y_osgb"][-1]:
                     continue
-                x_idx = np.searchsorted(pv_system["x"], image_xr["x"])
-                y_idx = np.searchsorted(pv_system["y"], image_xr["y"])
+                x_idx = np.searchsorted(pv_system["x_osgb"], image_xr["x_osgb"])
+                y_idx = np.searchsorted(pv_system["y_osgb"], image_xr["y_osgb"])
                 # Now go by the timestep to create cube of PV data
                 for time in range(len(pv_system.time.values)):
                     pv_image[time][x_idx][y_idx] += pv_system["data"][time]

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -9,12 +9,13 @@ from torchdata.datapipes.iter import IterDataPipe, Zipper
 
 @functional_datapipe("create_pv_image")
 class CreatePVImage(IterDataPipe):
-    def __init__(self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe):
+    def __init__(self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe, normalize: bool = False):
         """
         Creates 2D image of PV sites
         """
         self.source_datapipe = source_datapipe
         self.image_datapipe = image_datapipe
+        self.normalize = normalize
 
     def __iter__(self):
         for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
@@ -39,4 +40,7 @@ class CreatePVImage(IterDataPipe):
                     pv_image[time][x_idx][y_idx] += pv_system["data"][time]
 
             # TODO Construct Xarray object to return? Or add to PV data?
+            if self.normalize:
+                if np.max(pv_image) > 0:
+                    pv_image /= np.max(pv_image)
             yield pv_image

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -89,6 +89,7 @@ def _create_data_array_from_image(pv_image, pv_systems_xr, image_xr):
         ),
         name="pv_image",
     ).astype(np.float32)
+    data_array.attrs = image_xr.attrs
     return data_array
 
 def _get_idx_of_pixel_closest_to_poi_geostationary(

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -13,7 +13,14 @@ class CreatePVImage(IterDataPipe):
         self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe, normalize: bool = False
     ):
         """
-        Creates 2D image of PV sites
+        Creates a 3D data cube of PV output image x number of timesteps
+
+        TODO Include PV System IDs or something, currently just takes the outputs
+
+        Args:
+            source_datapipe: Source datapipe of PV data
+            image_datapipe: Datapipe emitting images to get the shape from, with coordinates
+            normalize: Whether to normalize based off the image max, or leave raw data
         """
         self.source_datapipe = source_datapipe
         self.image_datapipe = image_datapipe
@@ -45,4 +52,8 @@ class CreatePVImage(IterDataPipe):
             if self.normalize:
                 if np.max(pv_image) > 0:
                     pv_image /= np.max(pv_image)
+
+            # Should return Xarray as in Xarray transforms
+            # Same coordinates as the image xarray, so can take that
+
             yield pv_image

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -45,8 +45,8 @@ class CreatePVImageIterDataPipe(IterDataPipe):
             pv_image = np.zeros(
                 (
                     len(pv_systems_xr["time_utc"]),
-                    len(image_xr[self.x_dim]),
                     len(image_xr[self.y_dim]),
+                    len(image_xr[self.x_dim]),
                 ),
                 dtype=np.float32,
             )
@@ -99,8 +99,8 @@ def _create_data_array_from_image(pv_image, pv_systems_xr, image_xr):
         data=pv_image,
         coords=(
             ("time_utc", pv_systems_xr.time_utc.values),
-            ("x_geostationary", image_xr.x_geostationary.values),
             ("y_geostationary", image_xr.y_geostationary.values),
+            ("x_geostationary", image_xr.x_geostationary.values),
         ),
         name="pv_image",
     ).astype(np.float32)

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -1,16 +1,17 @@
 """Convert point PV sites to image output"""
 from typing import List
 
+import numpy as np
+import xarray as xr
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe, Zipper
-import xarray as xr
-import numpy as np
+
 
 @functional_datapipe("create_pv_image")
 class CreatePVImage(IterDataPipe):
     def __init__(self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe):
         """
-        Creates 2D image of PV sites 
+        Creates 2D image of PV sites
         """
         self.source_datapipe = source_datapipe
         self.image_datapipe = image_datapipe
@@ -18,7 +19,10 @@ class CreatePVImage(IterDataPipe):
     def __iter__(self):
         for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
             # Create empty image to use for the PV Systems, assumes image has x and y coordinates
-            pv_image = np.zeros((len(pv_systems_xr["time"]),len(image_xr["x"]), len(image_xr["y"])), dtype=np.float32)
+            pv_image = np.zeros(
+                (len(pv_systems_xr["time"]), len(image_xr["x"]), len(image_xr["y"])),
+                dtype=np.float32,
+            )
             # Coordinates should be in order for the image, so just need to do the search sorted thing to get the index to add the PV output to
             # Once all the outputs are added, then normalize? Could also normalize PV first, then normalize the normalized PV data
             # In either case have to iterate through all PV systems in example

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -13,6 +13,7 @@ from ocf_datapipes.utils.geospatial import load_geostationary_area_definition_an
 @functional_datapipe("create_pv_image")
 class CreatePVImageIterDataPipe(IterDataPipe):
     """Create PV image from individual sites"""
+
     def __init__(
         self,
         source_datapipe: IterDataPipe,
@@ -96,7 +97,11 @@ class CreatePVImageIterDataPipe(IterDataPipe):
             yield pv_image
 
 
-def _create_data_array_from_image(pv_image: np.ndarray, pv_systems_xr: Union[xr.Dataset, xr.DataArray], image_xr: Union[xr.Dataset, xr.DataArray]):
+def _create_data_array_from_image(
+    pv_image: np.ndarray,
+    pv_systems_xr: Union[xr.Dataset, xr.DataArray],
+    image_xr: Union[xr.Dataset, xr.DataArray],
+):
     data_array = xr.DataArray(
         data=pv_image,
         coords=(

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -30,7 +30,9 @@ class CreatePVImage(IterDataPipe):
                     continue
                 x_idx = np.searchsorted(pv_system["x"], image_xr["x"])
                 y_idx = np.searchsorted(pv_system["y"], image_xr["y"])
-                pv_image[x_idx][y_idx] += pv_system["data"]
+                # Now go by the timestep to create cube of PV data
+                for time in range(len(pv_system.time.values)):
+                    pv_image[time][x_idx][y_idx] += pv_system["data"][time]
 
             # TODO Construct Xarray object to return? Or add to PV data?
             yield pv_image

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -1,0 +1,22 @@
+"""Convert point PV sites to image output"""
+from typing import List
+
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, Zipper
+import xarray as xr
+import numpy as np
+
+@functional_datapipe("create_pv_image")
+class CreatePVImage(IterDataPipe):
+    def __init__(self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe):
+        """
+        Creates 2D image of PV sites 
+        """
+        self.source_datapipe = source_datapipe
+        self.image_datapipe = image_datapipe
+
+    def __iter__(self):
+        for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
+            # Create empty image to use for the PV Systems, assumes image has x and y coordinates
+            pv_image = np.zeros((len(pv_systems_xr["time"]),len(image_xr["x"]), len(image_xr["y"])), dtype=np.float32)
+

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -19,4 +19,18 @@ class CreatePVImage(IterDataPipe):
         for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
             # Create empty image to use for the PV Systems, assumes image has x and y coordinates
             pv_image = np.zeros((len(pv_systems_xr["time"]),len(image_xr["x"]), len(image_xr["y"])), dtype=np.float32)
+            # Coordinates should be in order for the image, so just need to do the search sorted thing to get the index to add the PV output to
+            # Once all the outputs are added, then normalize? Could also normalize PV first, then normalize the normalized PV data
+            # In either case have to iterate through all PV systems in example
+            for pv_system in pv_systems_xr["pv_system_id"]:
+                # Quick check as search sorted doesn't give an error if it is not in the range
+                if pv_system["x"] < image_xr["x"][0] or pv_system["x"] > image_xr["x"][-1]:
+                    continue
+                if pv_system["y"] < image_xr["y"][0] or pv_system["y"] > image_xr["y"][-1]:
+                    continue
+                x_idx = np.searchsorted(pv_system["x"], image_xr["x"])
+                y_idx = np.searchsorted(pv_system["y"], image_xr["y"])
+                pv_image[x_idx][y_idx] += pv_system["data"]
 
+            # TODO Construct Xarray object to return? Or add to PV data?
+            yield pv_image

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -9,7 +9,9 @@ from torchdata.datapipes.iter import IterDataPipe, Zipper
 
 @functional_datapipe("create_pv_image")
 class CreatePVImage(IterDataPipe):
-    def __init__(self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe, normalize: bool = False):
+    def __init__(
+        self, source_datapipe: IterDataPipe, image_datapipe: IterDataPipe, normalize: bool = False
+    ):
         """
         Creates 2D image of PV sites
         """

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -81,7 +81,7 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                     y_idx = np.searchsorted(pv_y, image_xr[self.y_dim])
                 # Now go by the timestep to create cube of PV data
                 for time in range(len(pv_system.time_utc.values)):
-                    pv_image[time][x_idx][y_idx] += pv_system[time].values
+                    pv_image[time][y_idx][x_idx] += pv_system[time].values
 
             if self.normalize:
                 if np.max(pv_image) > 0:

--- a/ocf_datapipes/transform/xarray/reproject_topographic_data.py
+++ b/ocf_datapipes/transform/xarray/reproject_topographic_data.py
@@ -58,7 +58,7 @@ def reproject_topo_data_from_osgb_to_geostationary(topo: xr.DataArray) -> xr.Dat
     topo_image = pyresample.image.ImageContainerQuick(topo.values, topo_osgb_area_def)
     topo_image_resampled = topo_image.resample(topo_geostationary_area_def)
     topo_dataarray = _get_data_array_of_resampled_topo_image(topo_image_resampled)
-    #topo_dataarray.attrs["area"] = str(topo_geostationary_area_def)
+    # topo_dataarray.attrs["area"] = str(topo_geostationary_area_def)
     return topo_dataarray
 
 

--- a/ocf_datapipes/transform/xarray/reproject_topographic_data.py
+++ b/ocf_datapipes/transform/xarray/reproject_topographic_data.py
@@ -57,7 +57,9 @@ def reproject_topo_data_from_osgb_to_geostationary(topo: xr.DataArray) -> xr.Dat
     topo_geostationary_area_def = _get_topo_geostationary_area_def(topo)
     topo_image = pyresample.image.ImageContainerQuick(topo.values, topo_osgb_area_def)
     topo_image_resampled = topo_image.resample(topo_geostationary_area_def)
-    return _get_data_array_of_resampled_topo_image(topo_image_resampled)
+    topo_dataarray = _get_data_array_of_resampled_topo_image(topo_image_resampled)
+    #topo_dataarray.attrs["area"] = str(topo_geostationary_area_def)
+    return topo_dataarray
 
 
 def _get_topo_osgb_area_def(topo: xr.DataArray) -> pyresample.geometry.AreaDefinition:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ bottleneck
 pyproj
 pyresample
 fastparquet
+scipy

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -177,7 +177,7 @@ def test_metnet_production(
         center_height=1_000_000,
         context_height=10_000_000,
         context_width=10_000_000,
-        output_width_pixels=512,
+        output_width_pixels=256,
         output_height_pixels=512,
     )
 

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -185,4 +185,3 @@ def test_metnet_production(
     print(batch.shape)
     batch = next(iter(gsp_datapipe))
     print(batch.shape)
-

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -181,6 +181,8 @@ def test_metnet_production(
     )
 
     batch = next(iter(combined_datapipe))
+    assert ~np.isnan(batch).any()
     print(batch.shape)
     batch = next(iter(gsp_datapipe))
     print(batch.shape)
+

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -171,7 +171,6 @@ def test_metnet_production(
             nwp_datapipe,
             pv_datapipe,
         ],
-        #topo_datapipe],
         location_datapipe=location_datapipe5,
         center_width=500_000,
         center_height=1_000_000,
@@ -182,4 +181,6 @@ def test_metnet_production(
     )
 
     batch = next(iter(combined_datapipe))
+    print(batch.shape)
+    batch = next(iter(gsp_datapipe))
     print(batch.shape)

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -170,14 +170,15 @@ def test_metnet_production(
             sat_datapipe,
             nwp_datapipe,
             pv_datapipe,
-        ],  # topo_datapipe],
+        ],
+        #topo_datapipe],
         location_datapipe=location_datapipe5,
-        center_width=100_000,
-        center_height=100_000,
-        context_height=1_000_000,
-        context_width=1_000_000,
-        output_width_pixels=200,
-        output_height_pixels=200,
+        center_width=500_000,
+        center_height=1_000_000,
+        context_height=10_000_000,
+        context_width=10_000_000,
+        output_width_pixels=512,
+        output_height_pixels=512,
     )
 
     batch = next(iter(combined_datapipe))

--- a/tests/end2end/test_metnet_training.py
+++ b/tests/end2end/test_metnet_training.py
@@ -1,9 +1,169 @@
-import ocf_datapipes
-from ocf_datapipes.utils.consts import BatchKey
+import numpy as np
+import torch
+import torchdata.datapipes as dp
+import xarray
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, Mapper
+from torchdata.datapipes.utils import to_graph
+
+xarray.set_options(keep_attrs=True)
+
+from datetime import timedelta
+
+from ocf_datapipes.batch import MergeNumpyExamplesToBatch, MergeNumpyModalities
+from ocf_datapipes.convert import (
+    ConvertGSPToNumpyBatch,
+    ConvertNWPToNumpyBatch,
+    ConvertPVToNumpyBatch,
+    ConvertSatelliteToNumpyBatch,
+)
+from ocf_datapipes.experimental import EnsureNNWPVariables, SetSystemIDsToOne
+from ocf_datapipes.select import (
+    DropGSP,
+    LocationPicker,
+    SelectLiveT0Time,
+    SelectLiveTimeSlice,
+    SelectSpatialSliceMeters,
+    SelectSpatialSlicePixels,
+    SelectTimeSlice,
+)
+from ocf_datapipes.transform.numpy import (
+    AddSunPosition,
+    AddTopographicData,
+    AlignGSPto5Min,
+    EncodeSpaceTime,
+    ExtendTimestepsToFuture,
+    SaveT0Time,
+)
+from ocf_datapipes.transform.xarray import (
+    AddT0IdxAndSamplePeriodDuration,
+    ConvertSatelliteToInt8,
+    ConvertToNWPTargetTime,
+    Downsample,
+    EnsureNPVSystemsPerExample,
+    Normalize,
+    ReprojectTopography,
+PreProcessMetNet,
+CreatePVImage
+)
+from ocf_datapipes.utils.consts import NWP_MEAN, NWP_STD, SAT_MEAN, SAT_STD, BatchKey
 
 
-def test_metnet_training_pipeline(
-    sat_datapipe, sat_hrv_datapipe, gsp_datapipe, passiv_datapipe, topo_datapipe
+def test_metnet_production(
+    sat_hrv_datapipe, sat_datapipe, passiv_datapipe, topo_datapipe, gsp_datapipe, nwp_datapipe
 ):
+    ####################################
+    #
+    # Equivalent to PP's loading and filtering methods
+    #
+    #####################################
+    # Normalize GSP and PV on whole dataset here
+    pv_datapipe = passiv_datapipe
+    gsp_datapipe, gsp_loc_datapipe = DropGSP(gsp_datapipe, gsps_to_keep=[0]).fork(2)
+    gsp_datapipe = Normalize(gsp_datapipe, normalize_fn=lambda x: x / x.capacity_megawatt_power)
+    topo_datapipe = ReprojectTopography(topo_datapipe)
+    sat_hrv_datapipe = AddT0IdxAndSamplePeriodDuration(
+        sat_hrv_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        history_duration=timedelta(minutes=60),
+    )
+    sat_datapipe = AddT0IdxAndSamplePeriodDuration(
+        sat_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        history_duration=timedelta(minutes=60),
+    )
+    pv_datapipe = AddT0IdxAndSamplePeriodDuration(
+        pv_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        history_duration=timedelta(minutes=60),
+    )
+    gsp_datapipe, gsp_t0_datapipe = AddT0IdxAndSamplePeriodDuration(
+        gsp_datapipe,
+        sample_period_duration=timedelta(minutes=30),
+        history_duration=timedelta(hours=2),
+    ).fork(2)
+    nwp_datapipe = AddT0IdxAndSamplePeriodDuration(
+        nwp_datapipe, sample_period_duration=timedelta(hours=1), history_duration=timedelta(hours=2)
+    )
 
-    pass
+    ####################################
+    #
+    # Equivalent to PP's xr_batch_processors and normal loading/selecting
+    #
+    #####################################
+
+    location_datapipe1, location_datapipe2, location_datapipe3, location_datapipe4, location_datapipe5 = LocationPicker(
+        gsp_loc_datapipe, return_all_locations=True
+    ).fork(
+        5
+    )  # Its in order then
+    pv_datapipe, pv_t0_datapipe = SelectSpatialSliceMeters(
+        pv_datapipe,
+        location_datapipe=location_datapipe1,
+        roi_width_meters=100_000,
+        roi_height_meters=100_000,
+    ).fork(2)  # Has to be large as test PV systems aren't in first 20 GSPs it seems
+    nwp_datapipe, nwp_t0_datapipe = Downsample(nwp_datapipe, y_coarsen=16, x_coarsen=16).fork(2)
+    nwp_t0_datapipe = SelectLiveT0Time(nwp_t0_datapipe, dim_name="init_time_utc")
+    nwp_datapipe = ConvertToNWPTargetTime(
+        nwp_datapipe,
+        t0_datapipe=nwp_t0_datapipe,
+        sample_period_duration=timedelta(hours=1),
+        history_duration=timedelta(hours=2),
+        forecast_duration=timedelta(hours=3),
+    )
+    gsp_t0_datapipe = SelectLiveT0Time(gsp_t0_datapipe)
+    gsp_datapipe = SelectLiveTimeSlice(
+        gsp_datapipe,
+        t0_datapipe=gsp_t0_datapipe,
+        history_duration=timedelta(hours=2),
+    )
+    sat_t0_datapipe = SelectLiveT0Time(sat_datapipe)
+    sat_datapipe, image_datapipe = SelectLiveTimeSlice(
+        sat_datapipe,
+        t0_datapipe=sat_t0_datapipe,
+        history_duration=timedelta(hours=1),
+    ).fork(2)
+    sat_hrv_t0_datapipe = SelectLiveT0Time(sat_hrv_datapipe)
+    sat_hrv_datapipe = SelectLiveTimeSlice(
+        sat_hrv_datapipe,
+        t0_datapipe=sat_hrv_t0_datapipe,
+        history_duration=timedelta(hours=1),
+    )
+    passiv_t0_datapipe = SelectLiveT0Time(pv_t0_datapipe)
+    pv_datapipe = SelectLiveTimeSlice(
+        pv_datapipe,
+        t0_datapipe=passiv_t0_datapipe,
+        history_duration=timedelta(hours=1),
+    )
+    gsp_datapipe = SelectSpatialSliceMeters(
+        gsp_datapipe,
+        location_datapipe=location_datapipe4,
+        dim_name="gsp_id",
+        roi_width_meters=10,
+        roi_height_meters=10,
+    )
+
+    pv_datapipe = CreatePVImage(pv_datapipe, image_datapipe)
+
+    sat_hrv_datapipe = Normalize(sat_hrv_datapipe, mean=SAT_MEAN["HRV"] / 4, std=SAT_STD["HRV"] / 4).map(
+        lambda x: x.resample(time_utc="5T").interpolate("linear")
+    )  # Interplate to 5 minutes incase its 15 minutes
+    sat_datapipe = Normalize(sat_datapipe, mean=SAT_MEAN["IR_016"], std=SAT_STD["IR_016"]).map(
+        lambda x: x.resample(time_utc="5T").interpolate("linear")
+    )  # Interplate to 5 minutes incase its 15 minutes
+    nwp_datapipe = Normalize(nwp_datapipe, mean=NWP_MEAN, std=NWP_STD)
+    topo_datapipe = Normalize(topo_datapipe, calculate_mean_std_from_example=True)
+
+    # Now combine in the MetNet format
+    combined_datapipe = PreProcessMetNet([sat_hrv_datapipe, sat_datapipe, nwp_datapipe, pv_datapipe,],# topo_datapipe],
+                                location_datapipe=location_datapipe5,
+                                center_width=100_000,
+                                center_height=100_000,
+                                context_height=1_000_000,
+                                context_width=1_000_000,
+                                output_width_pixels=200,
+                                output_height_pixels=200)
+
+    batch = next(iter(combined_datapipe))
+    print(batch.shape)

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -1,0 +1,8 @@
+from ocf_datapipes.transform.xarray import CreatePVImage
+import numpy as np
+
+def test_create_pv_image(passiv_datapipe, sat_datapipe):
+    pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe)
+    data = next(iter(pv_image_datapipe))
+    #print(data)
+    assert np.max(data) > 0

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -1,5 +1,7 @@
-from ocf_datapipes.transform.xarray import CreatePVImage
 import numpy as np
+
+from ocf_datapipes.transform.xarray import CreatePVImage
+
 
 def test_create_pv_image(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe)

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -4,5 +4,5 @@ import numpy as np
 def test_create_pv_image(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe)
     data = next(iter(pv_image_datapipe))
-    #print(data)
+    print(data)
     assert np.max(data) > 0

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -4,5 +4,4 @@ import numpy as np
 def test_create_pv_image(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe)
     data = next(iter(pv_image_datapipe))
-    print(data)
     assert np.max(data) > 0

--- a/tests/transform/xarray/test_metnet_preprocessor.py
+++ b/tests/transform/xarray/test_metnet_preprocessor.py
@@ -1,15 +1,16 @@
-from ocf_datapipes.transform.xarray import PreProcessMetNet
+from ocf_datapipes.transform.xarray import PreProcessMetNet, ConvertToNWPTargetTime
 from ocf_datapipes.select import DropGSP, LocationPicker
 
-def test_metnet_preprocess_satellite(sat_datapipe, nwp_datapipe, gsp_datapipe):
+def test_metnet_preprocess(sat_datapipe, nwp_datapipe, gsp_datapipe):
     gsp_datapipe = DropGSP(gsp_datapipe, gsps_to_keep=[0])
     gsp_datapipe = LocationPicker(gsp_datapipe)
+    nwp_datapipe = ConvertToNWPTargetTime(nwp_datapipe)
     datapipe = PreProcessMetNet([sat_datapipe, nwp_datapipe],
                                 location_datapipe=gsp_datapipe,
-                                center_width=10000,
-                                center_height=10000,
-                                context_height=100_000,
-                                context_width=100_000,
+                                center_width=100_000,
+                                center_height=100_000,
+                                context_height=1_000_000,
+                                context_width=1_000_000,
                                 output_width_pixels=100,
                                 output_height_pixels=100)
     data = next(iter(datapipe))

--- a/tests/transform/xarray/test_metnet_preprocessor.py
+++ b/tests/transform/xarray/test_metnet_preprocessor.py
@@ -2,12 +2,11 @@ from ocf_datapipes.select import DropGSP, LocationPicker
 from ocf_datapipes.transform.xarray import ConvertToNWPTargetTime, PreProcessMetNet
 
 
-def test_metnet_preprocess(sat_datapipe, nwp_datapipe, gsp_datapipe):
+def test_metnet_preprocess(sat_datapipe, gsp_datapipe):
     gsp_datapipe = DropGSP(gsp_datapipe, gsps_to_keep=[0])
     gsp_datapipe = LocationPicker(gsp_datapipe)
-    nwp_datapipe = ConvertToNWPTargetTime(nwp_datapipe)
     datapipe = PreProcessMetNet(
-        [sat_datapipe, nwp_datapipe],
+        [sat_datapipe],
         location_datapipe=gsp_datapipe,
         center_width=100_000,
         center_height=100_000,

--- a/tests/transform/xarray/test_metnet_preprocessor.py
+++ b/tests/transform/xarray/test_metnet_preprocessor.py
@@ -1,18 +1,21 @@
-from ocf_datapipes.transform.xarray import PreProcessMetNet, ConvertToNWPTargetTime
 from ocf_datapipes.select import DropGSP, LocationPicker
+from ocf_datapipes.transform.xarray import ConvertToNWPTargetTime, PreProcessMetNet
+
 
 def test_metnet_preprocess(sat_datapipe, nwp_datapipe, gsp_datapipe):
     gsp_datapipe = DropGSP(gsp_datapipe, gsps_to_keep=[0])
     gsp_datapipe = LocationPicker(gsp_datapipe)
     nwp_datapipe = ConvertToNWPTargetTime(nwp_datapipe)
-    datapipe = PreProcessMetNet([sat_datapipe, nwp_datapipe],
-                                location_datapipe=gsp_datapipe,
-                                center_width=100_000,
-                                center_height=100_000,
-                                context_height=1_000_000,
-                                context_width=1_000_000,
-                                output_width_pixels=100,
-                                output_height_pixels=100)
+    datapipe = PreProcessMetNet(
+        [sat_datapipe, nwp_datapipe],
+        location_datapipe=gsp_datapipe,
+        center_width=100_000,
+        center_height=100_000,
+        context_height=1_000_000,
+        context_width=1_000_000,
+        output_width_pixels=100,
+        output_height_pixels=100,
+    )
     data = next(iter(datapipe))
     print(data)
     print(data.shape)

--- a/tests/transform/xarray/test_metnet_preprocessor.py
+++ b/tests/transform/xarray/test_metnet_preprocessor.py
@@ -1,4 +1,17 @@
 from ocf_datapipes.transform.xarray import PreProcessMetNet
+from ocf_datapipes.select import DropGSP, LocationPicker
 
-def test_metnet_preprocess_satellite(sat_datapipe):
-    PreProcessMetNet([sat_datapipe])
+def test_metnet_preprocess_satellite(sat_datapipe, nwp_datapipe, gsp_datapipe):
+    gsp_datapipe = DropGSP(gsp_datapipe, gsps_to_keep=[0])
+    gsp_datapipe = LocationPicker(gsp_datapipe)
+    datapipe = PreProcessMetNet([sat_datapipe, nwp_datapipe],
+                                location_datapipe=gsp_datapipe,
+                                center_width=10000,
+                                center_height=10000,
+                                context_height=100_000,
+                                context_width=100_000,
+                                output_width_pixels=100,
+                                output_height_pixels=100)
+    data = next(iter(datapipe))
+    print(data)
+    print(data.shape)

--- a/tests/transform/xarray/test_metnet_preprocessor.py
+++ b/tests/transform/xarray/test_metnet_preprocessor.py
@@ -1,0 +1,4 @@
+from ocf_datapipes.transform.xarray import PreProcessMetNet
+
+def test_metnet_preprocess_satellite(sat_datapipe):
+    PreProcessMetNet([sat_datapipe])


### PR DESCRIPTION
# Pull Request

## Description

Adds datapipes needed for MetNet national forecast

Primarily: 
1. Converting PV data to images to stack datapipe
2. Stacking and cropping the context and area of interest datapipe

The other ones needed already exist


Fixes #

## How Has This Been Tested?

Unit tests

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
