### PR TITLE
Bump Caropy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch==1.12.1
 torchdata==0.4.1
-cartopy==0.19.0.post1
+Cartopy>=0.20.3
 torch
 xarray
 zarr

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     install_requires=install_requires,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    extras_require={"all": ["cartopy==0.19.0.post1"]},
     include_package_data=True,
     packages=find_packages(),
 )


### PR DESCRIPTION
## Description
Bump Cartopy. I can't install this package as it's currently specified.

## System
OS: Ubuntu 22.04
Python: 3.9.13