### PR TITLE
Speed up PV Image Creation

### DIFF
--- a/ocf_datapipes/training/metnet_national.py
+++ b/ocf_datapipes/training/metnet_national.py
@@ -193,13 +193,19 @@ def metnet_national_datapipe(
         secondary_datapipes.append(sat_hrv_time_periods_datapipe)
 
     if use_pv:
+        if use_hrv:
+            image_datapipe = OpenSatellite(configuration.input_data.hrvsatellite.hrvsatellite_zarr_path)
+        elif use_sat:
+            image_datapipe = OpenSatellite(configuration.input_data.satellite.satellite_zarr_path)
+        elif use_nwp:
+            image_datapipe = OpenNWP(configuration.input_data.nwp.nwp_zarr_path)
         logger.debug("Opening PV")
         pv_datapipe, pv_time_periods_datapipe = (
             OpenPVFromNetCDF(pv=configuration.input_data.pv)
             .add_t0_idx_and_sample_period_duration(
                 sample_period_duration=timedelta(minutes=5),
                 history_duration=timedelta(minutes=configuration.input_data.pv.history_minutes),
-            )
+            ).create_pv_image(image_datapipe, normalize=True, max_num_pv_systems=max_num_pv_systems, always_return_first=True)
             .fork(2)
         )
 
@@ -271,19 +277,12 @@ def metnet_national_datapipe(
     if use_pv:
         logger.debug("Take PV Time Slices")
         # take pv time slices
-        if use_sat:
-            sat_datapipe, image_datapipe = sat_datapipe.fork(2)
-        elif use_hrv:
-            sat_hrv_datapipe, image_datapipe = sat_hrv_datapipe.fork(2)
-        elif use_nwp:
-            nwp_datapipe, image_datapipe = nwp_datapipe.fork(2)
-
         pv_datapipe = pv_datapipe.select_time_slice(
             t0_datapipe=t0_datapipes[sum([use_nwp, use_sat, use_hrv, use_pv])],
             history_duration=timedelta(minutes=configuration.input_data.pv.history_minutes),
             forecast_duration=timedelta(minutes=0),
             sample_period_duration=timedelta(minutes=5),
-        ).create_pv_image(image_datapipe, normalize=True, max_num_pv_systems=max_num_pv_systems)
+        )
 
     if use_topo:
         topo_datapipe = OpenTopography(

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -105,11 +105,10 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                     x_idx = np.searchsorted(pv_x, image_xr[self.x_dim])
                     y_idx = np.searchsorted(pv_y, image_xr[self.y_dim])
                 # Now go by the timestep to create cube of PV data
-                # for time in range(len(pv_system.time_utc.values)):
                 pv_image[:, y_idx, x_idx] += pv_system.values
 
             if self.normalize:
-                if np.max(pv_image) > 0:
+                if np.nanmax(pv_image) > 0:
                     pv_image /= np.nanmax(pv_image)
             pv_image = np.nan_to_num(pv_image)
 

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -105,8 +105,8 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                     x_idx = np.searchsorted(pv_x, image_xr[self.x_dim])
                     y_idx = np.searchsorted(pv_y, image_xr[self.y_dim])
                 # Now go by the timestep to create cube of PV data
-                #for time in range(len(pv_system.time_utc.values)):
-                pv_image[:,y_idx,x_idx] += pv_system.values
+                # for time in range(len(pv_system.time_utc.values)):
+                pv_image[:, y_idx, x_idx] += pv_system.values
 
             if self.normalize:
                 if np.max(pv_image) > 0:

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -105,12 +105,12 @@ class CreatePVImageIterDataPipe(IterDataPipe):
                     x_idx = np.searchsorted(pv_x, image_xr[self.x_dim])
                     y_idx = np.searchsorted(pv_y, image_xr[self.y_dim])
                 # Now go by the timestep to create cube of PV data
-                for time in range(len(pv_system.time_utc.values)):
-                    pv_image[time][y_idx][x_idx] += pv_system[time].values
+                #for time in range(len(pv_system.time_utc.values)):
+                pv_image[:,y_idx,x_idx] += pv_system.values
 
             if self.normalize:
                 if np.max(pv_image) > 0:
-                    pv_image /= np.max(pv_image)
+                    pv_image /= np.nanmax(pv_image)
             pv_image = np.nan_to_num(pv_image)
 
             # Should return Xarray as in Xarray transforms

--- a/ocf_datapipes/transform/xarray/pv/create_pv_image.py
+++ b/ocf_datapipes/transform/xarray/pv/create_pv_image.py
@@ -24,6 +24,7 @@ class CreatePVImageIterDataPipe(IterDataPipe):
         normalize: bool = False,
         image_dim: str = "geostationary",
         max_num_pv_systems: int = -1,
+        always_return_first: bool = False,
         seed=None,
     ):
         """
@@ -37,6 +38,8 @@ class CreatePVImageIterDataPipe(IterDataPipe):
             normalize: Whether to normalize based off the image max, or leave raw data
             image_dim: Dimension name for the x and y dimensions
             max_num_pv_systems: Max number of PV systems to use
+            always_return_first: Always return the first image data cube, to save computation
+                Only use for if making the image at the beginning of the stack
             seed: Random seed to use if using max_num_pv_systems
         """
         self.source_datapipe = source_datapipe
@@ -46,6 +49,7 @@ class CreatePVImageIterDataPipe(IterDataPipe):
         self.y_dim = "y_" + image_dim
         self.max_num_pv_systems = max_num_pv_systems
         self.rng = np.random.default_rng(seed=seed)
+        self.always_return_first = always_return_first
 
     def __iter__(self) -> xr.DataArray:
         for pv_systems_xr, image_xr in Zipper(self.source_datapipe, self.image_datapipe):
@@ -115,6 +119,9 @@ class CreatePVImageIterDataPipe(IterDataPipe):
             # Should return Xarray as in Xarray transforms
             # Same coordinates as the image xarray, so can take that
             pv_image = _create_data_array_from_image(pv_image, pv_systems_xr, image_xr)
+            if self.always_return_first:
+                while True:
+                    yield pv_image
             yield pv_image
 
 

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -7,3 +7,9 @@ def test_create_pv_image(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe)
     data = next(iter(pv_image_datapipe))
     assert np.max(data) > 0
+
+def test_create_pv_image_normalized(passiv_datapipe, sat_datapipe):
+    pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe, normalize=True)
+    data = next(iter(pv_image_datapipe))
+    assert np.isclose(np.max(data), 1.0)
+    assert np.iscloase(np.min(data), 0.0)

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -13,4 +13,4 @@ def test_create_pv_image_normalized(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe, normalize=True)
     data = next(iter(pv_image_datapipe))
     assert np.isclose(np.max(data), 1.0)
-    assert np.iscloase(np.min(data), 0.0)
+    assert np.isclose(np.min(data), 0.0)

--- a/tests/transform/xarray/test_create_pv_image.py
+++ b/tests/transform/xarray/test_create_pv_image.py
@@ -8,6 +8,7 @@ def test_create_pv_image(passiv_datapipe, sat_datapipe):
     data = next(iter(pv_image_datapipe))
     assert np.max(data) > 0
 
+
 def test_create_pv_image_normalized(passiv_datapipe, sat_datapipe):
     pv_image_datapipe = CreatePVImage(passiv_datapipe, sat_datapipe, normalize=True)
     data = next(iter(pv_image_datapipe))


### PR DESCRIPTION
# Pull Request

## Description

Removes one for loop, so should reduce time. Also should be used to transform PV data at the beginning so its all in an image instead of per-example.

Fixes #

## How Has This Been Tested?

Unit test, and metnet end2end test

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
