### PR TITLE
Issue/add n gps per example

### DIFF
--- a/ocf_datapipes/transform/xarray/__init__.py
+++ b/ocf_datapipes/transform/xarray/__init__.py
@@ -25,6 +25,9 @@ from .get_contiguous_time_periods import (
     GetContiguousT0TimePeriodsIterDataPipe as GetContiguousT0TimePeriods,
 )
 from .gsp.create_gsp_image import CreateGSPImageIterDataPipe as CreateGSPImage
+from .gsp.ensure_n_gsp_per_example import (
+    EnsureNGSPSPerExampleIterDataPipe as EnsureNGSPSPerExampleIter,
+)
 from .metnet_preprocessor import PreProcessMetNetIterDataPipe as PreProcessMetNet
 from .normalize import NormalizeIterDataPipe as Normalize
 from .pv.create_pv_image import CreatePVImageIterDataPipe as CreatePVImage

--- a/ocf_datapipes/transform/xarray/gsp/ensure_n_gsp_per_example.py
+++ b/ocf_datapipes/transform/xarray/gsp/ensure_n_gsp_per_example.py
@@ -1,0 +1,60 @@
+"""Ensure there is N PV systems per example"""
+import logging
+
+import numpy as np
+import xarray as xr
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+logger = logging.getLogger(__name__)
+
+
+@functional_datapipe("ensure_n_gsp_per_example")
+class EnsureNGSPSPerExampleIterDataPipe(IterDataPipe):
+    """Ensure there is N GSP per example"""
+
+    def __init__(self, source_datapipe: IterDataPipe, n_gsps_per_example: int, seed=None):
+        """
+        Ensure there is N GSPS per example
+
+        Args:
+            source_datapipe: Datapipe of GSP data
+            n_gsps_per_example: Number of GSPS to have in example
+            seed: Random seed for choosing
+        """
+        self.source_datapipe = source_datapipe
+        self.n_gsps_per_example = n_gsps_per_example
+        self.rng = np.random.default_rng(seed=seed)
+
+    def __iter__(self):
+        for xr_data in self.source_datapipe:
+            if len(xr_data.gsp_id) > self.n_gsps_per_example:
+                logger.debug(f"Reducing GSPS to  {self.n_gsps_per_example}")
+                # More PV systems are available than we need. Reduce by randomly sampling:
+                subset_of_gsp_ids = self.rng.choice(
+                    xr_data.gsp_id,
+                    size=self.n_gsps_per_example,
+                    replace=False,
+                )
+                xr_data = xr_data.sel(gsp_id=subset_of_gsp_ids)
+            elif len(xr_data.gsp_id) < self.n_gsps_per_example:
+                logger.debug("Padding out GSP")
+                # If we just used `choice(replace=True)` then there's a high chance
+                # that the output won't include every available PV system but instead
+                # will repeat some PV systems at the expense of leaving some on the table.
+                # TODO: Don't repeat GSP. Pad with NaNs and mask the loss. Issue #73.
+                assert len(xr_data.gsp_id) > 0, (
+                    "There are no PV systems at all. " "We need at least one in an example"
+                )
+                n_random_gsps = self.n_gsps_per_example - len(xr_data.gsp_id)
+                allow_replacement = n_random_gsps > len(xr_data.gsp_id)
+                random_gsp_ids = self.rng.choice(
+                    xr_data.gsp_id,
+                    size=n_random_gsps,
+                    replace=allow_replacement,
+                )
+                xr_data = xr.concat(
+                    (xr_data, xr_data.sel(gsp_id=random_gsp_ids)),
+                    dim="gsp_id",
+                )
+            yield xr_data

--- a/ocf_datapipes/transform/xarray/gsp/ensure_n_gsp_per_example.py
+++ b/ocf_datapipes/transform/xarray/gsp/ensure_n_gsp_per_example.py
@@ -44,7 +44,7 @@ class EnsureNGSPSPerExampleIterDataPipe(IterDataPipe):
                 # will repeat some PV systems at the expense of leaving some on the table.
                 # TODO: Don't repeat GSP. Pad with NaNs and mask the loss. Issue #73.
                 assert len(xr_data.gsp_id) > 0, (
-                    "There are no PV systems at all. " "We need at least one in an example"
+                    "There are no GSPS at all. " "We need at least one in an example"
                 )
                 n_random_gsps = self.n_gsps_per_example - len(xr_data.gsp_id)
                 allow_replacement = n_random_gsps > len(xr_data.gsp_id)

--- a/tests/transform/xarray/gsp/test_ensure_gsp_examples.py
+++ b/tests/transform/xarray/gsp/test_ensure_gsp_examples.py
@@ -1,0 +1,15 @@
+
+from ocf_datapipes.transform.xarray import EnsureNGSPSPerExampleIter
+
+
+def test_create_gsp_image_expand(gsp_datapipe):
+    gsp_datapipe = EnsureNGSPSPerExampleIter(gsp_datapipe, n_gsps_per_example=123)
+    data = next(iter(gsp_datapipe))
+    assert len(data.gsp_id) == 123
+
+
+def test_create_gsp_image_reduce(gsp_datapipe):
+    gsp_datapipe = EnsureNGSPSPerExampleIter(gsp_datapipe, n_gsps_per_example=2)
+    data = next(iter(gsp_datapipe))
+    assert len(data.gsp_id) == 2
+


### PR DESCRIPTION
# Pull Request

## Description

add pipe line for selecting the number of gsps per example. 

This can be added to a datapipe as needed

I debated writing one function for 
- ensure_n_gsp_per_example.py
- ensure_n_pv_systems_per_example.py
as they are very similar, but I thought this was simple and made it easier to read

## How Has This Been Tested?

added tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
