### PR TITLE
raj/bad pv/trim dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # VSCode settings
 .vscode/
+ocf_datapipes.code-workspace

--- a/ocf_datapipes/select/__init__.py
+++ b/ocf_datapipes/select/__init__.py
@@ -16,3 +16,6 @@ from .select_t0_time import SelectT0TimeIterDataPipe as SelectT0Time
 from .select_time_periods import SelectTimePeriodsIterDataPipe as SelectTimePeriods
 from .select_time_slice import SelectTimeSliceIterDataPipe as SelectTimeSlice
 from .select_train_test import SelectTrainTestTimePeriodsIterDataPipe as SelectTrainTestTimePeriod
+from .trim_dates_with_insufficent_data import (
+    TrimDatesWithInsufficentDataIterDataPipe as TrimDatesWithInsufficentData,
+)

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 """
 This is a class function that slices a contigous datetime range to the 12th hour
 """
@@ -45,7 +42,7 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
         for xr_dataset in self.source_datapipe:
 
             # Getting the 'datetime' values into a single 1D array
-            dates_array = np.asarray(xr_dataset.coords["time_utc"].values)
+            dates_array = xr_dataset.coords["time_utc"].values
 
             # Checking if the total length of 'datetime' is
             # greater than provided time intervals
@@ -53,13 +50,13 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
 
                 # Counting the minute intervals (both non_zero and zero),
                 # as every 5min, 15min, or 30 min
-                # has intervals such as, for 15 min [0, 15, 20, 45, 0,........]
-                total_five_minutes = np.asarray(xr_dataset.time_utc.dt.minute.values, dtype=int)
-                count_five_minutes = np.count_nonzero(total_five_minutes) + np.count_nonzero(
-                    total_five_minutes == 0
-                )
+                # has intervals such as, for 15 min [0, 15, 30, 45, 0,........]
+                total_minute_intervals = xr_dataset.time_utc.dt.minute.values
+                count_minute_intervals = np.count_nonzero(
+                    total_minute_intervals
+                ) + np.count_nonzero(total_minute_intervals == 0)
                 # Collecting five minute intervals and counting them
-                logger.info(f"Total number of those five minutes are {count_five_minutes}")
+                logger.info(f"Total number of those five minutes are {count_minute_intervals}")
 
                 logger.info(
                     f"Checking if the count is a multiple of given interval {self.intervals}"
@@ -68,15 +65,15 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
                 # Checking if the minute intervals are multiples of total intervals in a day
                 # For example, datet time values of one day with five minute intervals
                 # consists of 288 five-minutes
-                check = count_five_minutes % self.intervals == 0.0
+                check = count_minute_intervals % self.intervals == 0.0
 
                 if not check:
                     # Counting number of intervals needed to be trimmed at the end
                     # The check would be always false, as in a given day,
                     # the last time step would be of the next day
-                    trim_dates_position = int(count_five_minutes % self.intervals)
+                    trim_dates_position = int(count_minute_intervals % self.intervals)
 
-                    # Number of intervalsneeded to be trimmed
+                    # Number of intervals needed to be trimmed
                     # at the end are trim_dates_position
                     trim_dates = dates_array[-trim_dates_position:]
                     logger.info(f"The trimmed dates are as follows {trim_dates}")

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -80,7 +80,5 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
 
                     # Dropping the dates coordinate variable data and its data in the xarray
                     xr_dataset = xr_dataset.drop_sel(time_utc=trim_dates)
-            else:
-                pass
 
             yield xr_dataset

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
     """Trim the date values of the Xarray Timeseries data"""
 
-    def __init__(self, source_datapipe: IterDataPipe, intervals: int):
+    def __init__(self, source_datapipe: IterDataPipe, minimum_number_data_points: int):
         """Trim the dates to the exact 12th hour
 
         For the five minute interval, If the time_utc dates are insufficent and
@@ -29,13 +29,13 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
 
         Args:
             source_datapipe: Xarray emitting timeseries data
-            intervals: Intervals respective of the time range
+            minimum_number_data_points: Minimum number of data intervals in a given day
                 5min xarray interval data = 288
                 15min xarray interval data = 96
                 .........
         """
         self.source_datapipe = source_datapipe
-        self.intervals = intervals
+        self.intervals = minimum_number_data_points
 
     def __iter__(self) -> xr.DataArray():
         # This dropping of insufficent data considers just dates in a given datetime

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -49,11 +49,7 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
 
             # Checking if the total length of 'datetime' is
             # greater than provided time intervals
-            logger.info(
-                f"Checking length of time series{len(dates_array)} longer than",
-                f"standard intervals {self.intervals}",
-            )
-            if len(dates_array) >= self.intervals:
+            if dates_array.size >= self.intervals:
 
                 # Counting the minute intervals (both non_zero and zero),
                 # as every 5min, 15min, or 30 min
@@ -79,11 +75,9 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
                     # The check would be always false, as in a given day,
                     # the last time step would be of the next day
                     trim_dates_position = int(count_five_minutes % self.intervals)
-                    logger.info(
-                        f"Number of {'intervals'} needed to be trimmed at the",
-                        f"end are {trim_dates_position}",
-                    )
-
+                    
+                    # Number of intervalsneeded to be trimmed 
+                    # at the end are trim_dates_position
                     trim_dates = dates_array[-trim_dates_position:]
                     logger.info(f"The trimmed dates are as follows {trim_dates}")
 

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -75,8 +75,8 @@ class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
                     # The check would be always false, as in a given day,
                     # the last time step would be of the next day
                     trim_dates_position = int(count_five_minutes % self.intervals)
-                    
-                    # Number of intervalsneeded to be trimmed 
+
+                    # Number of intervalsneeded to be trimmed
                     # at the end are trim_dates_position
                     trim_dates = dates_array[-trim_dates_position:]
                     logger.info(f"The trimmed dates are as follows {trim_dates}")

--- a/ocf_datapipes/select/trim_dates_with_insufficent_data.py
+++ b/ocf_datapipes/select/trim_dates_with_insufficent_data.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+This is a class function that slices a contigous datetime range to the 12th hour
+"""
+import logging
+
+import numpy as np
+import xarray as xr
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+logger = logging.getLogger(__name__)
+
+
+@functional_datapipe("trim_dates_with_insufficent_data")
+class TrimDatesWithInsufficentDataIterDataPipe(IterDataPipe):
+    """Trim the date values of the Xarray Timeseries data"""
+
+    def __init__(self, source_datapipe: IterDataPipe, intervals: int):
+        """Trim the dates to the exact 12th hour
+
+        For the five minute interval, If the time_utc dates are insufficent and
+        less than multiple of 289, this method trims that extended dates
+
+        For example:
+            <xr.DataArray> time_utc : "2020-01-01T00:00"..."2020-01-02T00:00"..."2020-01-02T06:00"
+
+        This method trims the inusfficent less than one day data at
+        the end and provides full set of complete one day interval (5min or 15min or...)
+
+        Args:
+            source_datapipe: Xarray emitting timeseries data
+            intervals: Intervals respective of the time range
+                5min xarray interval data = 288
+                15min xarray interval data = 96
+                .........
+        """
+        self.source_datapipe = source_datapipe
+        self.intervals = intervals
+
+    def __iter__(self) -> xr.DataArray():
+        # This dropping of insufficent data considers just dates in a given datetime
+        for xr_dataset in self.source_datapipe:
+
+            # Getting the 'datetime' values into a single 1D array
+            dates_array = np.asarray(xr_dataset.coords["time_utc"].values)
+
+            # Checking if the total length of 'datetime' is
+            # greater than provided time intervals
+            logger.info(
+                f"Checking length of time series{len(dates_array)} longer than",
+                f"standard intervals {self.intervals}",
+            )
+            if len(dates_array) >= self.intervals:
+
+                # Counting the minute intervals (both non_zero and zero),
+                # as every 5min, 15min, or 30 min
+                # has intervals such as, for 15 min [0, 15, 20, 45, 0,........]
+                total_five_minutes = np.asarray(xr_dataset.time_utc.dt.minute.values, dtype=int)
+                count_five_minutes = np.count_nonzero(total_five_minutes) + np.count_nonzero(
+                    total_five_minutes == 0
+                )
+                # Collecting five minute intervals and counting them
+                logger.info(f"Total number of those five minutes are {count_five_minutes}")
+
+                logger.info(
+                    f"Checking if the count is a multiple of given interval {self.intervals}"
+                )
+
+                # Checking if the minute intervals are multiples of total intervals in a day
+                # For example, datet time values of one day with five minute intervals
+                # consists of 288 five-minutes
+                check = count_five_minutes % self.intervals == 0.0
+
+                if not check:
+                    # Counting number of intervals needed to be trimmed at the end
+                    # The check would be always false, as in a given day,
+                    # the last time step would be of the next day
+                    trim_dates_position = int(count_five_minutes % self.intervals)
+                    logger.info(
+                        f"Number of {'intervals'} needed to be trimmed at the",
+                        f"end are {trim_dates_position}",
+                    )
+
+                    trim_dates = dates_array[-trim_dates_position:]
+                    logger.info(f"The trimmed dates are as follows {trim_dates}")
+
+                    # Dropping the dates coordinate variable data and its data in the xarray
+                    xr_dataset = xr_dataset.drop_sel(time_utc=trim_dates)
+            else:
+                pass
+
+            yield xr_dataset

--- a/tests/select/test_trim_dates.py
+++ b/tests/select/test_trim_dates.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from ocf_datapipes.select import TrimDatesWithInsufficentData
+
+
+def test_trim_lessthan_oneday(passiv_datapipe):
+    data = TrimDatesWithInsufficentData(passiv_datapipe, intervals=288)
+    data = next(iter(data))
+    count = len(data.coords["time_utc"].values)
+    assert count % 288 == 0
+
+
+def test_with_pvoutput_datapipe(pvoutput_datapipe):
+    after_trim_date = TrimDatesWithInsufficentData(pvoutput_datapipe, intervals=288)
+
+    before_data = next(iter(pvoutput_datapipe))
+    after_data = next(iter(after_trim_date))
+
+    assert len(before_data.coords["time_utc"].values) == len(after_data.coords["time_utc"].values)
+
+
+def test_constructed_xarray():
+    def construct_multi_daterange(freq: str, periods: np.int32, start: str = "2022-01-01"):
+        time_range = pd.date_range(start=start, freq=freq, periods=periods)
+        pv_system_id = [1, 2, 3]
+        ALL_COORDS = {"time_utc": time_range, "pv_system_id": pv_system_id}
+
+        data = np.zeros((len(time_range), len(pv_system_id)))
+        data[:, 2] = np.nan
+
+        data_array = xr.DataArray(
+            data,
+            coords=ALL_COORDS,
+        )
+        return data_array
+
+    # Different data array with different time ranges
+    # Data_array1 extends to a second day with five minute intervals
+    # Data_array2 does not have full day (30min) intervals
+    # Data_array3 extends more than ~8days
+    data_array1 = construct_multi_daterange(freq="5T", periods=350)
+    data_array2 = construct_multi_daterange(freq="30T", periods=25)
+    data_array3 = construct_multi_daterange(freq="5T", periods=2500)
+    trim_date1_5min_interval = TrimDatesWithInsufficentData([data_array1], intervals=288)
+    trim_date2_30min_interval = TrimDatesWithInsufficentData([data_array2], intervals=48)
+    trim_date3_5min_interval = TrimDatesWithInsufficentData([data_array3], intervals=288)
+
+    data1 = next(iter(trim_date1_5min_interval))
+    data2 = next(iter(trim_date2_30min_interval))
+    data3 = next(iter(trim_date3_5min_interval))
+
+    # Function slices data_array1 dates to a single day
+    # Function does not slice any dates in data_array2,
+    # as it has dates less than a day
+    # Function slices data_array3 dates to the 12th hour and,
+    # remaining dates are a multiple of 5-minute intervals in a day (288)
+    assert len(data1.coords["time_utc"].values) == 288
+    assert len(data2.coords["time_utc"].values) == 25
+    assert len(data3.coords["time_utc"].values) % 288 == 0.0

--- a/tests/select/test_trim_dates.py
+++ b/tests/select/test_trim_dates.py
@@ -6,14 +6,16 @@ from ocf_datapipes.select import TrimDatesWithInsufficentData
 
 
 def test_trim_lessthan_oneday(passiv_datapipe):
-    data = TrimDatesWithInsufficentData(passiv_datapipe, intervals=288)
+    data = TrimDatesWithInsufficentData(passiv_datapipe, minimum_number_data_points=288)
     data = next(iter(data))
     count = len(data.coords["time_utc"].values)
     assert count % 288 == 0
 
 
 def test_with_pvoutput_datapipe(pvoutput_datapipe):
-    after_trim_date = TrimDatesWithInsufficentData(pvoutput_datapipe, intervals=288)
+    after_trim_date = TrimDatesWithInsufficentData(
+        pvoutput_datapipe, minimum_number_data_points=288
+    )
 
     before_data = next(iter(pvoutput_datapipe))
     after_data = next(iter(after_trim_date))
@@ -43,9 +45,15 @@ def test_constructed_xarray():
     data_array1 = construct_multi_daterange(freq="5T", periods=350)
     data_array2 = construct_multi_daterange(freq="30T", periods=25)
     data_array3 = construct_multi_daterange(freq="5T", periods=2500)
-    trim_date1_5min_interval = TrimDatesWithInsufficentData([data_array1], intervals=288)
-    trim_date2_30min_interval = TrimDatesWithInsufficentData([data_array2], intervals=48)
-    trim_date3_5min_interval = TrimDatesWithInsufficentData([data_array3], intervals=288)
+    trim_date1_5min_interval = TrimDatesWithInsufficentData(
+        [data_array1], minimum_number_data_points=288
+    )
+    trim_date2_30min_interval = TrimDatesWithInsufficentData(
+        [data_array2], minimum_number_data_points=48
+    )
+    trim_date3_5min_interval = TrimDatesWithInsufficentData(
+        [data_array3], minimum_number_data_points=288
+    )
 
     data1 = next(iter(trim_date1_5min_interval))
     data2 = next(iter(trim_date2_30min_interval))


### PR DESCRIPTION
# Pull Request

## Description

An incoming `xarray` dataset contains `time_utc` coordinate values with contiguous time intervals. The type of `time_utc` coordinate intervals can be `5min` or `15min`or `30min`. The trim dates function takes in `xarray` dataset and trims the `time_utc` coordinate values to the 12th hour only if the total number of `time_utc` values is greater than the given `intervals`

Fixes #

## How Has This Been Tested?

This function has been tested with `passiv_datapipe`, `pvoutput_datpipe`, and a constructed `xarray` `data array`. The constructed `xarray` has three different `time_utc` ranges with different configurations. The function trims the dates to the 12th hour and does not do anything if `time_utc` values are not sufficient.

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
