### PR TITLE
Work with lists of satellite inputs

### DIFF
--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -27,7 +27,7 @@ def open_sat_data(zarr_path: Union[Path, str, list[Union[str, Path]]]) -> xr.Dat
     dask.config.set({"array.slicing.split_large_chunks": False})
 
     # Open the data
-    if type(zarr_path) == list or "*" in str(zarr_path):  # Multi-file dataset
+    if type(zarr_path) is list or "*" in str(zarr_path):  # Multi-file dataset
         dataset = (
             xr.open_mfdataset(
                 zarr_path,

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -27,7 +27,7 @@ def open_sat_data(zarr_path: Union[Path, str, list[Union[str, Path]]]) -> xr.Dat
     dask.config.set({"array.slicing.split_large_chunks": False})
 
     # Open the data
-    if type(zarr_path) is list or "*" in str(zarr_path):  # Multi-file dataset
+    if type(zarr_path) in [list, tuple] or "*" in str(zarr_path):  # Multi-file dataset
         dataset = (
             xr.open_mfdataset(
                 zarr_path,

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -27,7 +27,7 @@ def open_sat_data(zarr_path: Union[Path, str, list[Union[str, Path]]]) -> xr.Dat
     dask.config.set({"array.slicing.split_large_chunks": False})
 
     # Open the data
-    if isinstance(zarr_path, list) or "*" in str(zarr_path):  # Multi-file dataset
+    if type(zarr_path) == list or "*" in str(zarr_path):  # Multi-file dataset
         dataset = (
             xr.open_mfdataset(
                 zarr_path,

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -13,7 +13,7 @@ from torchdata.datapipes.iter import IterDataPipe
 _log = logging.getLogger(__name__)
 
 
-def open_sat_data(zarr_path: Union[Path, str]) -> xr.DataArray:
+def open_sat_data(zarr_path: Union[Path, str, list[Union[str, Path]]]) -> xr.DataArray:
     """Lazily opens the Zarr store.
 
     Args:
@@ -27,7 +27,7 @@ def open_sat_data(zarr_path: Union[Path, str]) -> xr.DataArray:
     dask.config.set({"array.slicing.split_large_chunks": False})
 
     # Open the data
-    if "*" in str(zarr_path):  # Multi-file dataset
+    if isinstance(zarr_path, list) or "*" in str(zarr_path):  # Multi-file dataset
         dataset = (
             xr.open_mfdataset(
                 zarr_path,


### PR DESCRIPTION
# Pull Request

## Description

Adds support for lists of satellite inputs, instead of wildcard.

This can be helpful for example, fsspec can be very slow when using the wildcard from GCP, but passing in a list of `open_mfdataset` is very quick.

## How Has This Been Tested?

Unit tests

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
