### PR TITLE
Add Caching to Disk in Datapipe

### DIFF
--- a/ocf_datapipes/training/metnet_pv_site.py
+++ b/ocf_datapipes/training/metnet_pv_site.py
@@ -3,8 +3,8 @@ import datetime
 import logging
 from pathlib import Path
 from typing import Union
-import numpy as np
 
+import numpy as np
 import xarray
 from torchdata.datapipes.iter import IterDataPipe
 
@@ -218,11 +218,17 @@ def metnet_site_datapipe(
     if not pv_in_image:
         pv_history = pv_history.map(_remove_nans)
         pv_history = ConvertPVToNumpy(pv_history, return_pv_id=True)
-        combined_datapipe = metnet_datapipe.batch(batch_size).zip_ocf(
-            pv_history.batch(batch_size), pv_datapipe.batch(batch_size)
-        ).on_disk_cache(filepath_fn=_filepath_fn)
+        combined_datapipe = (
+            metnet_datapipe.batch(batch_size)
+            .zip_ocf(pv_history.batch(batch_size), pv_datapipe.batch(batch_size))
+            .on_disk_cache(filepath_fn=_filepath_fn)
+        )
     else:
-        combined_datapipe = metnet_datapipe.batch(batch_size).zip_ocf(pv_datapipe.batch(batch_size)).on_disk_cache(filepath_fn=_filepath_fn)
+        combined_datapipe = (
+            metnet_datapipe.batch(batch_size)
+            .zip_ocf(pv_datapipe.batch(batch_size))
+            .on_disk_cache(filepath_fn=_filepath_fn)
+        )
 
     if cache_to_disk:
         combined_datapipe = combined_datapipe.end_caching()

--- a/ocf_datapipes/training/metnet_pv_site.py
+++ b/ocf_datapipes/training/metnet_pv_site.py
@@ -43,10 +43,12 @@ def _remove_nans(x):
 def _load_xarray_values(x):
     return x.load()
 
+
 def _filepath_fn(xr_data):
     # Get filepath from metadata, including time, and location and return it
     file_name = f"{xr_data.time.values[0]}_{xr_data.pv_system_id.values[0]}_{xr_data.x_osgb.values[0]}_{xr_data.y_osgb.values[0]}.npy"
     return file_name
+
 
 def metnet_site_datapipe(
     configuration_filename: Union[Path, str],

--- a/tests/training/test_metnet_pv_site.py
+++ b/tests/training/test_metnet_pv_site.py
@@ -16,9 +16,12 @@ def test_metnet_datapipe():
     assert np.isfinite(batch[0]).all()
     assert np.isfinite(batch[1]).all()
 
+
 def test_metnet_datapipe_cache():
     filename = os.path.join(os.path.dirname(ocf_datapipes.__file__), "../tests/config/test.yaml")
-    gsp_datapipe = metnet_site_datapipe(filename, use_nwp=False, pv_in_image=True, cache_to_disk=True)
+    gsp_datapipe = metnet_site_datapipe(
+        filename, use_nwp=False, pv_in_image=True, cache_to_disk=True
+    )
 
     batch = next(iter(gsp_datapipe))
     assert np.isfinite(batch[0]).all()

--- a/tests/training/test_metnet_pv_site.py
+++ b/tests/training/test_metnet_pv_site.py
@@ -15,3 +15,11 @@ def test_metnet_datapipe():
     batch = next(iter(gsp_datapipe))
     assert np.isfinite(batch[0]).all()
     assert np.isfinite(batch[1]).all()
+
+def test_metnet_datapipe_cache():
+    filename = os.path.join(os.path.dirname(ocf_datapipes.__file__), "../tests/config/test.yaml")
+    gsp_datapipe = metnet_site_datapipe(filename, use_nwp=False, pv_in_image=True, cache_to_disk=True)
+
+    batch = next(iter(gsp_datapipe))
+    assert np.isfinite(batch[0]).all()
+    assert np.isfinite(batch[1]).all()


### PR DESCRIPTION
# Pull Request

## Description

This gives the option to cache to disk the outputs of some datapipes, and gives examples in the training pipeline on how to do so. This should help with compute intensive data pipelines.

Fixes #

## How Has This Been Tested?

Unit tests and running it.

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
