### PR TITLE
add alternative parameters to select time

### DIFF
--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -1,6 +1,7 @@
 """Selects time slice"""
+import logging
 from datetime import timedelta
-from typing import Union
+from typing import Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -9,6 +10,8 @@ from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 from ocf_datapipes.utils import Zipper
+
+logger = logging.getLogger(__name__)
 
 
 @functional_datapipe("select_time_slice")
@@ -19,35 +22,55 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         self,
         source_datapipe: IterDataPipe,
         t0_datapipe: IterDataPipe,
-        history_duration: timedelta,
-        forecast_duration: timedelta,
         sample_period_duration: timedelta,
-    ):
+        history_duration: Optional[timedelta] = None,
+        forecast_duration: Optional[timedelta] = None,
+        interval_start: Optional[timedelta] = None,
+        interval_end: Optional[timedelta] = None,
+):
         """
-        Selects time slice
+        Selects time slice. Either `history_duration` and `history_duration` or `interval_start` and
+        `interval_end` must be supplied.
 
         Args:
             source_datapipe: Datapipe of Xarray objects
             t0_datapipe: Datapipe of t0 times
-            history_duration: History time used
-            forecast_duration: Forecast time used
             sample_period_duration: Sample period of xarray data
+            history_duration (optional): History time used
+            forecast_duration (optional): Forecast time used
+            interval_start (optional): timedelta with respect to t0 where the open interval begins
+            interval_end (optional): timedelta with respect to t0 where the open interval ends
         """
         self.source_datapipe = source_datapipe
         self.t0_datapipe = t0_datapipe
-        self.history_duration = np.timedelta64(history_duration)
-        self.forecast_duration = np.timedelta64(forecast_duration)
+        
+        used_duration = (history_duration is not None and forecast_duration is not None) 
+        used_intervals = (interval_start is not None and interval_end is not None) 
+        assert used_duration ^ used_intervals, "Either durations, or intervals must be supplied"
+        
+        if used_duration:
+            self.interval_start = - np.timedelta64(history_duration)
+            self.interval_end = np.timedelta64(forecast_duration)
+        elif used_intervals:
+            self.interval_start = np.timedelta64(interval_start)
+            self.interval_end = np.timedelta64(interval_end)
+        
         self.sample_period_duration = sample_period_duration
-
+    
     def __iter__(self) -> Union[xr.DataArray, xr.Dataset]:
-        for xr_data, t0 in Zipper(self.source_datapipe, self.t0_datapipe):
+        xr_data = next(iter(self.source_datapipe))
+        
+        for t0 in self.t0_datapipe:
             t0_datetime_utc = pd.Timestamp(t0)
-            start_dt = t0_datetime_utc - self.history_duration
-            end_dt = t0_datetime_utc + self.forecast_duration
-            xr_data = xr_data.sel(
+            start_dt = t0_datetime_utc + self.interval_start
+            end_dt = t0_datetime_utc + self.interval_end
+
+            start_dt = start_dt.ceil(self.sample_period_duration)
+            end_dt = end_dt.ceil(self.sample_period_duration)
+
+            yield xr_data.sel(
                 time_utc=slice(
-                    start_dt.ceil(self.sample_period_duration),
-                    end_dt.ceil(self.sample_period_duration),
+                    start_dt,
+                    end_dt,
                 )
             )
-            yield xr_data

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -1,17 +1,44 @@
+from datetime import timedelta
+import pandas as pd
+from torchdata.datapipes.iter import IterableWrapper
 from ocf_datapipes.select import SelectTimeSlice
 
 
-def test_select_time_slice_passiv(passiv_datapipe):
-    pass
-
-
-def test_select_time_slice_hrv(sat_hrv_datapipe):
-    pass
-
-
-def test_select_time_slice_gsp(gsp_datapipe):
-    pass
-
-
-def test_select_time_slice_nwp(nwp_datapipe):
-    pass
+def test_select_time_slice_sat(sat_datapipe):
+    data = next(iter(sat_datapipe))
+    
+    t0_datapipe = IterableWrapper(
+        pd.to_datetime(data.time_utc.values)[3:6]
+    )
+    
+    # Check with history and forecast durations
+    dp = SelectTimeSlice(
+        sat_datapipe,
+        t0_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        history_duration = timedelta(minutes=5),
+        forecast_duration = timedelta(minutes=5),
+    )
+    
+    sat_samples = list(dp)
+    t0_values = list(t0_datapipe)
+    
+    for sat_sample, t0 in zip(sat_samples, t0_values):
+        assert len(sat_sample.time_utc)==3
+        assert sat_sample.time_utc[1]==t0
+    
+    # Check again with intervals
+    dp = SelectTimeSlice(
+        sat_datapipe,
+        t0_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        interval_start = timedelta(minutes=-5),
+        interval_end = timedelta(minutes=5),
+    )
+    
+    
+    sat_samples = list(dp)
+    
+    for sat_sample, t0 in zip(sat_samples, t0_values):
+        assert len(sat_sample.time_utc)==3
+        assert sat_sample.time_utc[1]==t0


### PR DESCRIPTION
# Pull Request

## Description

Add new optional parameters  to select relative intervals rather than history and forecast. Closes #165.

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
