### PR TITLE
attempt to load 15 minute data if needed for satellite

### DIFF
--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -61,7 +61,8 @@ def open_sat_data(
     Args:
       zarr_path: Cloud URL or local path pattern, or list of these. If GCS URL, it must start with
           'gs://'.
-      use_15_minute_data_if_needed: use_15_minute_data_if_needed: Option to use the 15 minute data if the 5 minute data is not available
+      use_15_minute_data_if_needed: use_15_minute_data_if_needed: Option to use the 15 minute data
+        if the 5 minute data is not available
         This is done by checking to see if the last timestamp is within an hour from now
 
     Example:
@@ -193,10 +194,11 @@ def load_and_check_satellite_data(zarr_path) -> [xr.Dataset, bool]:
     If 1. or 2. are true, then return True for use_15_minute_data
 
     Args:
-        use_15_minute_data:
-        zarr_path:
+        zarr_path: the zarr path to load
 
     Returns:
+        dataset (if loaded),
+        use_15_minute_data, indicating if the 15 minute data should be loaded
     """
     filesystem = fsspec.open(Pathy.fluid(zarr_path)).fs
     if filesystem.exists(zarr_path):
@@ -225,7 +227,8 @@ def check_last_timestamp(dataset: xr.Dataset, timedelta_hours: float = 1) -> boo
     now = datetime.utcnow()
     if latest_time < now - timedelta(hours=timedelta_hours):
         _log.info(
-            f"last datestamp is {latest_time}, which is more than {timedelta_hours} hour ago from {now} "
+            f"last datestamp is {latest_time}, which is more than "
+            f"{timedelta_hours} hour ago from {now} "
             f"Will try to load 15 minute data"
         )
         return True
@@ -243,7 +246,8 @@ class OpenSatelliteIterDataPipe(IterDataPipe):
 
         Args:
             zarr_path: path to the zarr file
-            use_15_minute_data_if_needed: Option to use the 15 minute data if the 5 minute data is not available
+            use_15_minute_data_if_needed: Option to use the 15 minute data if the
+                5 minute data is not available
         """
         self.zarr_path = zarr_path
         self.use_15_minute_data_if_needed = use_15_minute_data_if_needed

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -1,8 +1,12 @@
 """Satellite loader"""
 import logging
+import fsspec
 import subprocess
 from pathlib import Path
+from pathy import Pathy
 from typing import Union
+
+from datetime import datetime, timedelta, timezone
 
 import dask
 import pandas as pd
@@ -50,12 +54,14 @@ def _get_single_sat_data(zarr_path: Union[Path, str]) -> xr.DataArray:
     return dataset
 
 
-def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]]) -> xr.DataArray:
+def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]], use_15_minute_data_if_needed: bool = False) -> xr.DataArray:
     """Lazily opens the Zarr store.
 
     Args:
       zarr_path: Cloud URL or local path pattern, or list of these. If GCS URL, it must start with
           'gs://'.
+      use_15_minute_data_if_needed: use_15_minute_data_if_needed: Option to use the 15 minute data if the 5 minute data is not available
+        This is done by checking to see if the last timestamp is within an hour from now
 
     Example:
         With wild cards and GCS path:
@@ -82,6 +88,9 @@ def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]]) -> xr.Data
     # from 8 seconds to 50 seconds!
     dask.config.set({"array.slicing.split_large_chunks": False})
 
+    # dont load 15 minute data by default
+    use_15_minute_data = False
+
     if isinstance(zarr_path, (list, tuple)):
         dataset = xr.combine_nested(
             [_get_single_sat_data(path) for path in zarr_path],
@@ -90,8 +99,27 @@ def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]]) -> xr.Data
             join="override",
         )
     else:
-        dataset = _get_single_sat_data(zarr_path)
-    # TODO add 15 mins data satellite option
+        filesystem = fsspec.open(Pathy.fluid(zarr_path)).fs
+        if filesystem.exists(zarr_path):
+            dataset = _get_single_sat_data(zarr_path)
+
+            use_15_minute_data = check_last_timestamp(dataset, use_15_minute_data)
+
+        else:
+            _log.info(
+                f"File does not exist {zarr_path}. Will try to load 15 minute data"
+            )
+            use_15_minute_data = True
+
+    if use_15_minute_data_if_needed and use_15_minute_data:
+        zarr_path_15_minutes = str(zarr_path).replace(".zarr", "_15.zarr")
+
+        _log.debug(f"Now going to load {zarr_path_15_minutes} and resample")
+        dataset = _get_single_sat_data(zarr_path_15_minutes)
+
+        dataset = dataset.load()
+        _log.debug("Resampling 15 minute data to 5 mins")
+        dataset = dataset.resample(time="5T").interpolate("linear")
 
     # Remove data coordinate dimensions if they exist
     if "x_geostationary_coordinates" in dataset:
@@ -164,22 +192,46 @@ def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]]) -> xr.Data
     return data_array
 
 
+def check_last_timestamp(dataset: xr.Dataset, timedelta_hours:float= 1) -> bool:
+    """
+    Check the last timestamp of the dataset to see if it is more than 1 hour ago
+
+    Args:
+        dataset: dataset with time dimension
+        timedelta_hours: the timedelta to check from now
+
+    Returns: bool
+    """
+    latest_time = pd.to_datetime(dataset.time[-1].values)
+    if latest_time < datetime.now(tz=timezone.utc) - timedelta(hours=timedelta_hours):
+        _log.info(
+            f"last datestamp is {latest_time}, which is more than 1 hour ago. "
+            f"Will try to load 15 minute data"
+        )
+        return True
+    else:
+        return False
+
+
 @functional_datapipe("open_satellite")
 class OpenSatelliteIterDataPipe(IterDataPipe):
     """Open Satellite Zarr"""
 
-    def __init__(self, zarr_path: Union[Path, str]):
+    def __init__(self, zarr_path: Union[Path, str], use_15_minute_data_if_needed: bool = False):
         """
         Opens the satellite Zarr
 
         Args:
             zarr_path: path to the zarr file
+            use_15_minute_data_if_needed: Option to use the 15 minute data if the 5 minute data is not available
         """
         self.zarr_path = zarr_path
+        self.use_15_minute_data_if_needed = use_15_minute_data_if_needed
         super().__init__()
 
     def __iter__(self) -> xr.DataArray:
         """Open the Zarr file"""
-        data: xr.DataArray = open_sat_data(zarr_path=self.zarr_path)
+        data: xr.DataArray = open_sat_data(zarr_path=self.zarr_path,
+                                           use_15_minute_data_if_needed=self.use_15_minute_data_if_needed)
         while True:
             yield data

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -1,7 +1,7 @@
 """Satellite loader"""
 import logging
 import subprocess
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Union
 
@@ -184,7 +184,7 @@ def open_sat_data(
     return data_array
 
 
-def load_and_check_satellite_data(zarr_path)->[xr.Dataset, bool]:
+def load_and_check_satellite_data(zarr_path) -> [xr.Dataset, bool]:
     """
     Load the satellite data,
 

--- a/ocf_datapipes/load/satellite.py
+++ b/ocf_datapipes/load/satellite.py
@@ -1,17 +1,16 @@
 """Satellite loader"""
 import logging
-import fsspec
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from pathy import Pathy
 from typing import Union
 
-from datetime import datetime, timedelta, timezone
-
 import dask
+import fsspec
 import pandas as pd
 import xarray as xr
 from ocf_blosc2 import Blosc2  # noqa: F401
+from pathy import Pathy
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
@@ -54,7 +53,9 @@ def _get_single_sat_data(zarr_path: Union[Path, str]) -> xr.DataArray:
     return dataset
 
 
-def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]], use_15_minute_data_if_needed: bool = False) -> xr.DataArray:
+def open_sat_data(
+    zarr_path: Union[Path, str, list[Path], list[str]], use_15_minute_data_if_needed: bool = False
+) -> xr.DataArray:
     """Lazily opens the Zarr store.
 
     Args:
@@ -106,9 +107,7 @@ def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]], use_15_min
             use_15_minute_data = check_last_timestamp(dataset, use_15_minute_data)
 
         else:
-            _log.info(
-                f"File does not exist {zarr_path}. Will try to load 15 minute data"
-            )
+            _log.info(f"File does not exist {zarr_path}. Will try to load 15 minute data")
             use_15_minute_data = True
 
     if use_15_minute_data_if_needed and use_15_minute_data:
@@ -192,7 +191,7 @@ def open_sat_data(zarr_path: Union[Path, str, list[Path], list[str]], use_15_min
     return data_array
 
 
-def check_last_timestamp(dataset: xr.Dataset, timedelta_hours:float= 1) -> bool:
+def check_last_timestamp(dataset: xr.Dataset, timedelta_hours: float = 1) -> bool:
     """
     Check the last timestamp of the dataset to see if it is more than 1 hour ago
 
@@ -231,7 +230,8 @@ class OpenSatelliteIterDataPipe(IterDataPipe):
 
     def __iter__(self) -> xr.DataArray:
         """Open the Zarr file"""
-        data: xr.DataArray = open_sat_data(zarr_path=self.zarr_path,
-                                           use_15_minute_data_if_needed=self.use_15_minute_data_if_needed)
+        data: xr.DataArray = open_sat_data(
+            zarr_path=self.zarr_path, use_15_minute_data_if_needed=self.use_15_minute_data_if_needed
+        )
         while True:
             yield data

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -93,7 +93,10 @@ def open_and_return_datapipes(
     if use_sat:
         logger.debug("Opening Satellite Data")
         sat_datapipe = (
-            OpenSatellite(configuration.input_data.satellite.satellite_zarr_path, use_15_minute_data_if_needed=production)
+            OpenSatellite(
+                configuration.input_data.satellite.satellite_zarr_path,
+                use_15_minute_data_if_needed=production,
+            )
             .select_channels(configuration.input_data.satellite.satellite_channels)
             .add_t0_idx_and_sample_period_duration(
                 sample_period_duration=timedelta(minutes=5),
@@ -102,8 +105,6 @@ def open_and_return_datapipes(
                 ),
             )
         )
-
-
 
         used_datapipes["sat"] = sat_datapipe
 

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -38,6 +38,7 @@ def open_and_return_datapipes(
         use_hrv: Whether to open HRV satellite data
         use_sat: Whether to open non-HRV satellite data
         use_gsp: Whether to use GSP data or not
+        production: bool if this is for production or not
 
     Returns:
         List of datapipes corresponding to the datapipes to open

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -25,6 +25,7 @@ def open_and_return_datapipes(
     use_sat: bool = True,
     use_hrv: bool = True,
     use_topo: bool = True,
+    production: bool = False,
 ) -> dict[str, IterDataPipe]:
     """
     Open data sources given a configuration and return the list of datapipes
@@ -92,7 +93,7 @@ def open_and_return_datapipes(
     if use_sat:
         logger.debug("Opening Satellite Data")
         sat_datapipe = (
-            OpenSatellite(configuration.input_data.satellite.satellite_zarr_path)
+            OpenSatellite(configuration.input_data.satellite.satellite_zarr_path, use_15_minute_data_if_needed=production)
             .select_channels(configuration.input_data.satellite.satellite_channels)
             .add_t0_idx_and_sample_period_duration(
                 sample_period_duration=timedelta(minutes=5),
@@ -101,6 +102,8 @@ def open_and_return_datapipes(
                 ),
             )
         )
+
+
 
         used_datapipes["sat"] = sat_datapipe
 

--- a/tests/load/test_load_satellite.py
+++ b/tests/load/test_load_satellite.py
@@ -1,4 +1,18 @@
+""" Loading satellite tests
+
+1. Open HRV data
+2. Open data
+3. Open 15 data
+4. Try to open 5, then open 15
+5. Test load_and_check_satellite_data, loads data
+6. Test load_and_check_satellite_data, no file
+7. Test load_and_check_satellite_data, old data
+
+
+"""
 from ocf_datapipes.load import OpenSatellite
+from ocf_datapipes.load.satellite import load_and_check_satellite_data
+from freezegun import freeze_time
 
 
 def test_open_satellite():
@@ -17,3 +31,36 @@ def test_open_satellite_15():
     sat_datapipe = OpenSatellite(zarr_path="tests/data/sat_data_15.zarr")
     metadata = next(iter(sat_datapipe))
     assert metadata is not None
+
+
+def test_open_satellite_5_then_15():
+    sat_datapipe = OpenSatellite(
+        zarr_path="tests/data/sat_data.zarr", use_15_minute_data_if_needed=True
+    )
+    metadata = next(iter(sat_datapipe))
+    assert metadata is not None
+
+
+@freeze_time("2020-04-01 14:00:00")
+def test_load_and_check_satellite_data():
+    dataset, use_15_minute_data = load_and_check_satellite_data(
+        zarr_path="tests/data/sat_data.zarr"
+    )
+    assert dataset is not None
+    assert use_15_minute_data is False
+
+
+def test_load_and_check_satellite_data_no_file():
+    dataset, use_15_minute_data = load_and_check_satellite_data(
+        zarr_path="tests/data/sat_data_zzzzz.zarr"
+    )
+    assert dataset is None
+    assert use_15_minute_data is True
+
+
+def test_load_and_check_satellite_old_data():
+    dataset, use_15_minute_data = load_and_check_satellite_data(
+        zarr_path="tests/data/sat_data_zzzzz.zarr"
+    )
+    assert dataset is None
+    assert use_15_minute_data is True


### PR DESCRIPTION
# Pull Request

## Description

- Ability to load 15 minute satellite data if needed. This is done by checking the last timestamp and seeing if its less than 1 hour ago

Helps https://github.com/openclimatefix/PVNet/issues/31

## How Has This Been Tested?

- CI tests
- Added a test, to load 15 minute data, if no 5 minute data
- Added a test, to load 15 minute data, if 5 minute data is odd 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
