### PR TITLE
fix time filtering for NWP dropout

### DIFF
--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -336,7 +336,7 @@ def create_t0_and_loc_datapipes(
         key_for_t0: Key to use for the t0 datapipe. Must be "gsp" or "pv".
         shuffle: Whether to use the internal shuffle function when yielding location times. Else
             location times will be heavily ordered.
-        nwp_max_dropout_minutes: If using dropout on NWP, sometimes we have to go back to previous 
+        nwp_max_dropout_minutes: If using dropout on NWP, sometimes we have to go back to previous
             NWP init time. In order to accomodate for this possibility in selecting times, set
             `nwp_max_dropout_minutes` as the max NWP dropout delay you plan to use.
 
@@ -357,12 +357,11 @@ def create_t0_and_loc_datapipes(
 
         elif key == "nwp":
             sample_frequency = 180  # Init times are 3 hours apart
-            
+
             # If using NWP dropout we need to make sure the previous forecast is available
             # Setting the history to larger here will do the required filtering
             history_duration = max(
-                configuration.input_data.nwp.history_minutes, 
-                nwp_max_dropout_minutes
+                configuration.input_data.nwp.history_minutes, nwp_max_dropout_minutes
             )
             forecast_duration = configuration.input_data.nwp.forecast_minutes
             time_dim = "init_time_utc"

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -322,7 +322,7 @@ def create_t0_and_loc_datapipes(
     configuration: Configuration,
     key_for_t0: str = "gsp",
     shuffle: bool = True,
-    nwp_max_t0_offset: timedelta = timedelta(minutes=0),
+    nwp_max_dropout_minutes: int = 0,
 ):
     """
     Takes source datapipes and returns datapipes of appropriate sample pairs of locations and times.
@@ -336,9 +336,9 @@ def create_t0_and_loc_datapipes(
         key_for_t0: Key to use for the t0 datapipe. Must be "gsp" or "pv".
         shuffle: Whether to use the internal shuffle function when yielding location times. Else
             location times will be heavily ordered.
-        nwp_max_t0_offset: If using dropout on NWP, sometimes we have to go back to previous NWP
-            init time. In order to accomodat for this possibility in selecting times, set
-            `nwp_max_t0_offset` as the max NWP dropout delay you plan to use.
+        nwp_max_dropout_minutes: If using dropout on NWP, sometimes we have to go back to previous 
+            NWP init time. In order to accomodate for this possibility in selecting times, set
+            `nwp_max_dropout_minutes` as the max NWP dropout delay you plan to use.
 
     Returns:
         location datapipe, t0 datapipe
@@ -357,38 +357,39 @@ def create_t0_and_loc_datapipes(
 
         elif key == "nwp":
             sample_frequency = 180  # Init times are 3 hours apart
-            history_duration = configuration.input_data.nwp.history_minutes
+            
+            # If using NWP dropout we need to make sure the previous forecast is available
+            # Setting the history to larger here will do the required filtering
+            history_duration = max(
+                configuration.input_data.nwp.history_minutes, 
+                nwp_max_dropout_minutes
+            )
             forecast_duration = configuration.input_data.nwp.forecast_minutes
             time_dim = "init_time_utc"
-            max_t0_offset = nwp_max_t0_offset
 
         elif key == "sat":
             sample_frequency = 5
             history_duration = configuration.input_data.satellite.history_minutes
             forecast_duration = 0
             time_dim = "time_utc"
-            max_t0_offset = timedelta(minutes=0)
 
         elif key == "hrv":
             sample_frequency = 5
             history_duration = configuration.input_data.hrvsatellite.history_minutes
             forecast_duration = 0
             time_dim = "time_utc"
-            max_t0_offset = timedelta(minutes=0)
 
         elif key == "pv":
             sample_frequency = 5
             history_duration = configuration.input_data.pv.history_minutes
             forecast_duration = configuration.input_data.pv.forecast_minutes
             time_dim = "time_utc"
-            max_t0_offset = timedelta(minutes=0)
 
         elif key == "gsp":
             sample_frequency = 30
             history_duration = configuration.input_data.gsp.history_minutes
             forecast_duration = configuration.input_data.gsp.forecast_minutes
             time_dim = "time_utc"
-            max_t0_offset = timedelta(minutes=0)
 
         else:
             raise ValueError(f"Unexpected key: {key}")
@@ -400,7 +401,6 @@ def create_t0_and_loc_datapipes(
             history_duration=timedelta(minutes=history_duration),
             forecast_duration=timedelta(minutes=forecast_duration),
             time_dim=time_dim,
-            max_t0_offset=max_t0_offset,
         )
 
         contiguous_time_datapipes.append(time_periods)

--- a/ocf_datapipes/training/pvnet.py
+++ b/ocf_datapipes/training/pvnet.py
@@ -280,7 +280,7 @@ def construct_loctime_pipelines(
         configuration=config,
         key_for_t0="gsp",
         shuffle=True,
-        nwp_max_t0_offset=minutes(180),
+        nwp_max_dropout_minutes=180,
     )
 
     return location_pipe, t0_datapipe


### PR DESCRIPTION
# Pull Request

## Description

The time filtering used previously was not properly taking into account the NWP dropout and the fact that it might select a previous timestamp as if the most recent NWP was not available. This caused some edge cases where the pipeline would fail. 

This fixes the issue

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
