### PR TITLE
Minor issues in PV data from database

### DIFF
--- a/ocf_datapipes/load/pv/live.py
+++ b/ocf_datapipes/load/pv/live.py
@@ -249,10 +249,13 @@ def get_pv_power_from_database(
     # encode pv system id
     for provider in pv_output, solar_sheffield_passiv:
         idx = pv_yields_df["provider"] == provider
-
-        pv_yields_df.loc[idx, "pv_system_id"] = encode_label(
-            pv_yields_df.loc[idx, "pv_system_id"], label=provider
-        )
+        
+        # If not idx.any() we try to assign to no indices and the data type is changed from int to 
+        # float. Avoid this with if statement.
+        if idx.any():
+            pv_yields_df.loc[idx, "pv_system_id"] = encode_label(
+                pv_yields_df.loc[idx, "pv_system_id"], label=provider
+            )
 
     # pivot on
     pv_yields_df = pv_yields_df[["datetime_utc", "pv_system_id", "solar_generation_kw"]]

--- a/ocf_datapipes/load/pv/live.py
+++ b/ocf_datapipes/load/pv/live.py
@@ -260,7 +260,7 @@ def get_pv_power_from_database(
     # pivot on
     pv_yields_df = pv_yields_df[["datetime_utc", "pv_system_id", "solar_generation_kw"]]
     pv_yields_df.drop_duplicates(
-        ["datetime_utc", "pv_system_id", "solar_generation_kw"], keep="last", inplace=True
+        ["datetime_utc", "pv_system_id"], keep="last", inplace=True
     )
     pv_yields_df = pv_yields_df.pivot(
         index="datetime_utc", columns="pv_system_id", values="solar_generation_kw"

--- a/ocf_datapipes/load/pv/live.py
+++ b/ocf_datapipes/load/pv/live.py
@@ -247,7 +247,7 @@ def get_pv_power_from_database(
     )
 
     # encode pv system id
-    for provider in pv_output, solar_sheffield_passiv:
+    for provider in providers:
         idx = pv_yields_df["provider"] == provider
         
         # If not idx.any() we try to assign to no indices and the data type is changed from int to 
@@ -256,6 +256,8 @@ def get_pv_power_from_database(
             pv_yields_df.loc[idx, "pv_system_id"] = encode_label(
                 pv_yields_df.loc[idx, "pv_system_id"], label=provider
             )
+        else:
+            logger.warning(f"Found no pv yields for provider : {providers}")
 
     # pivot on
     pv_yields_df = pv_yields_df[["datetime_utc", "pv_system_id", "solar_generation_kw"]]


### PR DESCRIPTION
# Pull Request

## Description

Two small changes

- Stop the ID datatype being changed from integer to float during encoding
- Make sure for each (ID, timestamp) pair we only have one row for the power output. The previous version of dropping duplicates of (ID, timestamp, PV output) was causing an error in the table pivot when accessing the development database. There seem to be multiple rows for each (ID, timestamp) in that database.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
