### PR TITLE
Add functionality to use linear interpolation to fill gaps in input data

### DIFF
--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -1,7 +1,7 @@
 """Selects time slice"""
 import logging
 from datetime import timedelta
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 
 import numpy as np
 import pandas as pd
@@ -10,6 +10,48 @@ from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 logger = logging.getLogger(__name__)
+
+
+
+def fill_1d_bool_gaps(x, max_gap, fill_ends=False):
+    """In a boolean array, fill consecutive False elements their number is less than the gap_size.
+    
+    Args:
+        x: A 1-dimensional boolean array
+        max_gap: integer of the maximum gap size which will be filled with True
+        fill_ends: Whether to fill the ends as if there are True values on either side
+        
+    Returns:
+        A 1-dimensional boolean array
+    
+    Examples:
+        >>> x = np.array([0, 1, 0, 0, 1, 0, 1, 0])
+        >>> fill_1d_bool_gaps(x, max_gap=2, fill_ends=False).astype(int)
+        array([0, 1, 1, 1, 1, 1, 1, 0])
+        
+        >>> x = np.array([0, 1, 0, 0, 1, 0, 1, 0])
+        >>> fill_1d_bool_gaps(x, max_gap=1, fill_ends=True).astype(int)
+        array([1, 1, 0, 0, 1, 1, 1, 1])
+    """
+    if fill_ends:
+        x_extended = np.concatenate([[True], x, [True]])
+        return fill_1d_bool_gaps(x_extended, max_gap, fill_ends=False)[1:-1]
+    
+    should_fill = np.zeros(len(x), dtype=bool)
+    
+    i_start = None
+
+    last_b = False
+    for i, b in enumerate(x):
+        if last_b and not b:
+            i_start = i
+        elif b and not last_b and i_start is not None:
+            if i-i_start<=max_gap:
+                should_fill[i_start:i] = True
+            i_start = None
+        last_b = b
+    
+    return np.logical_or(should_fill, x)
 
 
 @functional_datapipe("select_time_slice")
@@ -26,6 +68,7 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         interval_start: Optional[timedelta] = None,
         interval_end: Optional[timedelta] = None,
         fill_selection: Optional[bool] = False,
+        max_steps_gap: Optional[int] = 0,
     ):
         """
         Selects time slice.
@@ -43,16 +86,23 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
             interval_end (optional): timedelta with respect to t0 where the open interval ends
             fill_selection (optional): If True, and if the data yielded from `source_datapipe` does
                 not extend over the entire requested time period. The missing timestamps are filled
-                with NaN values in the returned xarray object. Else the default xarray slicing
-                behaviour is used.
+                in the returned xarray object tyo give the expected shape. Else the default xarray 
+                slicing behaviour is used and timestamps may be missing. When filled, the values are
+                linearly interpolated up to a gap size of `max_steps_gap` steps. If outside this 
+                range, the values are set to NaN.
+            max_steps_gap (optional): The number of consecutive missing time steps which will be 
+                filled via linear interpolation. If set to zero, no interpolation is used and all 
+                missing timesteps will be NaN.
         """
         self.source_datapipe = source_datapipe
         self.t0_datapipe = t0_datapipe
         self.fill_selection = fill_selection
+        self.max_steps_gap = max_steps_gap
 
         used_duration = history_duration is not None and forecast_duration is not None
         used_intervals = interval_start is not None and interval_end is not None
         assert used_duration ^ used_intervals, "Either durations, or intervals must be supplied"
+        assert max_steps_gap >= 0, "max_steps_gap must be >= 0 "
 
         if used_duration:
             self.interval_start = -np.timedelta64(history_duration)
@@ -62,6 +112,13 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
             self.interval_end = np.timedelta64(interval_end)
 
         self.sample_period_duration = sample_period_duration
+        
+        if self.fill_selection and max_steps_gap==0:
+            self._sel = self._sel_fillnan
+        elif self.fill_selection and max_steps_gap>0:
+            self._sel = self._sel_fillinterp
+        else:
+            self._sel = self._sel_default
 
     def _sel_fillnan(self, xr_data, start_dt, end_dt):
         requested_times = pd.date_range(
@@ -71,6 +128,58 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         )
         # Missing time indexes are returned with all NaN values
         return xr_data.reindex(time_utc=requested_times)
+    
+    def _sel_fillinterp(self, xr_data, start_dt, end_dt):
+        dt_buffer = self.sample_period_duration*self.max_steps_gap
+        
+        # Initially select larger period so we can use it to interpolate to requested period
+        # This slice also avoids us interpolating the whole dataset to get the requested times
+        ds = xr_data.sel(time_utc=slice(start_dt-dt_buffer, end_dt+dt_buffer))
+        
+        # These are the times we will ultimately return
+        requested_times = pd.date_range(
+            start_dt,
+            end_dt,
+            freq=self.sample_period_duration,
+        )
+        
+        # If all the requested times are present we avoid running interpolation
+        if np.isin(requested_times, ds.time_utc).all():
+            return ds.sel(time_utc=slice(start_dt, end_dt))
+        
+        logger.info("Some requested times are missing - running interpolation")
+        # These are the times we use for interpolation to the requested_times
+        buffer_requested_times = pd.date_range(
+            start_dt-dt_buffer,
+            end_dt+dt_buffer,
+            freq=self.sample_period_duration,
+        )
+
+        # Find the timestamps which are within max gap size
+        mask = np.isin(buffer_requested_times, ds.time_utc)
+        valid_fill_times = fill_1d_bool_gaps(mask, self.max_steps_gap, fill_ends=False)
+
+        # Run the interpolation and filter to requested times
+        ds_interp = ds.interp(time_utc=buffer_requested_times, method="linear", assume_sorted=True)
+
+        # Mask the timestamps outside the max gap size
+        valid_fill_times_xr = xr.zeros_like(ds_interp.time_utc, dtype=bool)
+        valid_fill_times_xr.values[:] = valid_fill_times
+        
+        valid_requested_times = valid_fill_times_xr.sel(time_utc=slice(start_dt, end_dt))
+        if not valid_requested_times.all():
+            not_infilled_times = valid_requested_times.where(~valid_requested_times, drop=True)
+            logger.warning(
+                "After interpolation the following requested times are still missing:"
+                f"{not_infilled_times.time_utc.values}"
+            )
+            
+        ds_out = ds_interp.where(valid_fill_times_xr)
+        
+        # Filter to selected times
+        ds_out = ds_out.sel(time_utc=slice(start_dt, end_dt))
+        
+        return ds_out
 
     def _sel_default(self, xr_data, start_dt, end_dt):
         return xr_data.sel(time_utc=slice(start_dt, end_dt))
@@ -86,7 +195,4 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
             start_dt = start_dt.ceil(self.sample_period_duration)
             end_dt = end_dt.ceil(self.sample_period_duration)
 
-            if self.fill_selection:
-                yield self._sel_fillnan(xr_data, start_dt, end_dt)
-            else:
-                yield self._sel_default(xr_data, start_dt, end_dt)
+            yield self._sel(xr_data, start_dt, end_dt)

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def fill_1d_bool_gaps(x, max_gap, fill_ends=False):
-    """In a boolean array, fill consecutive False elements their number is less than the gap_size.
+    """In a boolean array, fill consecutive False elements if their number is less than the gap_size.
 
     Args:
         x: A 1-dimensional boolean array

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -146,9 +146,9 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         requested_time_exists = np.isin(requested_times, ds.time_utc)
         if requested_time_exists.all():
             return ds.sel(time_utc=slice(start_dt, end_dt))
-        
+
         # If less than 2 of the requested times are present we cannot infill
-        if requested_time_exists.sum()<2:
+        if requested_time_exists.sum() < 2:
             logger.warning("Cannot run interpolate infilling with less than 2 time steps available")
             return self._sel_fillnan(xr_data, start_dt, end_dt)
 

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def fill_1d_bool_gaps(x, max_gap, fill_ends=False):
-    """In a boolean array, fill consecutive False elements if their number is less than the gap_size.
+    """In a boolean array, fill consecutive False elements if their number is less than the gap_size
 
     Args:
         x: A 1-dimensional boolean array

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -141,7 +141,7 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
             end_dt,
             freq=self.sample_period_duration,
         )
-        
+
         # These are the times we use for interpolation to the requested_times
         buffer_requested_times = pd.date_range(
             start_dt - dt_buffer,

--- a/ocf_datapipes/training/pvnet.py
+++ b/ocf_datapipes/training/pvnet.py
@@ -366,6 +366,7 @@ def slice_datapipes_by_time(
             interval_start=minutes(-conf_in.satellite.history_minutes),
             interval_end=sat_delay,
             fill_selection=production,
+            max_steps_gap=2,
         )
 
         # Generate randomly sampled dropout times
@@ -399,6 +400,7 @@ def slice_datapipes_by_time(
             interval_start=minutes(-conf_in.hrvsatellite.history_minutes),
             interval_end=sat_delay,
             fill_selection=production,
+            max_steps_gap=2,
         )
 
         # Apply the dropout

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -86,9 +86,8 @@ def test_select_time_slice_sat(sat_datapipe):
     # ------------------- Check with interpolation --------------------
 
     data_times = pd.to_datetime(data.time_utc.values)
-    t0_datapipe = IterableWrapper(data_times[[0, 1, 4, 5]])
-
-    missing_sat_data = data.sel(time_utc=data_times[[0, 2, 3, 6]])
+    missing_sat_data = data.sel(time_utc=data_times[[0, 2, 3, 6, 7, 9]])
+    t0_datapipe = IterableWrapper(data_times[[0, 1, 4, 5, 7]])
     missing_sat_datapipe = IterableWrapper([missing_sat_data]).repeat(len(t0_datapipe))
 
     # For each sample the timestamps should be missing in this order
@@ -98,6 +97,7 @@ def test_select_time_slice_sat(sat_datapipe):
             [False, False, False],
             [False, True, True],
             [True, True, False],
+            [False, False, False],
         ]
     )
 
@@ -119,4 +119,7 @@ def test_select_time_slice_sat(sat_datapipe):
         assert sat_samples[i].time_utc[1] == t0_values[i]
         # Correct number of time steps are all NaN
         sat_sel = sat_samples[i].isel(x_geostationary=0, y_geostationary=0, channel=0)
-        assert (np.isnan(sat_sel.values) == expected_missing_steps[i]).all()
+        
+        assert (np.isnan(sat_sel.values) == expected_missing_steps[i]).all(), (
+            f"{np.isnan(sat_sel.values)}!={expected_missing_steps[i]}"
+        )

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -3,14 +3,26 @@ import pandas as pd
 import numpy as np
 from torchdata.datapipes.iter import IterableWrapper
 from ocf_datapipes.select import SelectTimeSlice
+from ocf_datapipes.select.select_time_slice import fill_1d_bool_gaps
 
+
+def test_fill_1d_bool_gaps():
+    x = np.array([0, 1, 0, 0, 1, 0, 1, 0])
+    y = fill_1d_bool_gaps(x, max_gap=2, fill_ends=False).astype(int)
+    assert (np.array([0, 1, 1, 1, 1, 1, 1, 0]) == y).all()
+
+    x = np.array([0, 1, 0, 0, 1, 0, 1, 0])
+    y = fill_1d_bool_gaps(x, max_gap=1, fill_ends=True).astype(int)
+    assert (np.array([1, 1, 0, 0, 1, 1, 1, 1]) == y).all()
+    
 
 def test_select_time_slice_sat(sat_datapipe):
     data = next(iter(sat_datapipe))
 
     t0_datapipe = IterableWrapper(pd.to_datetime(data.time_utc.values)[3:6])
 
-    # Check with history and forecast durations
+    # ----------- Check with history and forecast durations -----------
+    
     dp = SelectTimeSlice(
         sat_datapipe,
         t0_datapipe,
@@ -25,8 +37,9 @@ def test_select_time_slice_sat(sat_datapipe):
     for sat_sample, t0 in zip(sat_samples, t0_values):
         assert len(sat_sample.time_utc) == 3
         assert sat_sample.time_utc[1] == t0
-
-    # Check again with intervals
+    
+    # ------------------ Check again with intervals -------------------
+    
     dp = SelectTimeSlice(
         sat_datapipe,
         t0_datapipe,
@@ -41,7 +54,8 @@ def test_select_time_slice_sat(sat_datapipe):
         assert len(sat_sample.time_utc) == 3
         assert sat_sample.time_utc[1] == t0
 
-    # Check with out of bounds selection
+    # -------------- Check with out of bounds selection ---------------
+    
     t_last = pd.to_datetime(data.time_utc.values[-1])
     t0_values = [
         t_last - timedelta(minutes=5),
@@ -68,3 +82,40 @@ def test_select_time_slice_sat(sat_datapipe):
         # Correct number of time steps are all NaN
         sat_sel = sat_sample.isel(x_geostationary=0, y_geostationary=0, channel=0)
         assert np.isnan(sat_sel.values).sum() == i
+        
+    # ------------------- Check with interpolation --------------------
+    
+    data_times = pd.to_datetime(data.time_utc.values)
+    t0_datapipe = IterableWrapper(data_times[[0,1,4,5]])
+    
+    missing_sat_data = data.sel(time_utc=data_times[[0,2,3,6]])
+    missing_sat_datapipe = IterableWrapper([missing_sat_data]).repeat(len(t0_datapipe))
+    
+    # For each sample the timestamps should be missing in this order
+    expected_missing_steps = np.array([
+        [True, False, False],
+        [False, False, False],
+        [False, True, True],
+        [True, True, False],
+    ])
+
+
+    dp = SelectTimeSlice(
+        missing_sat_datapipe,
+        t0_datapipe,
+        sample_period_duration=timedelta(minutes=5),
+        interval_start=timedelta(minutes=-5),
+        interval_end=timedelta(minutes=5),
+        fill_selection=True,
+        max_steps_gap=1,
+    )
+
+    sat_samples = list(dp)
+    t0_values = list(t0_datapipe)
+
+    for i in range(len(sat_samples)):
+        assert len(sat_samples[i].time_utc) == 3
+        assert sat_samples[i].time_utc[1] == t0_values[i]
+        # Correct number of time steps are all NaN
+        sat_sel = sat_samples[i].isel(x_geostationary=0, y_geostationary=0, channel=0)
+        assert (np.isnan(sat_sel.values) == expected_missing_steps[i]).all()

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -119,7 +119,7 @@ def test_select_time_slice_sat(sat_datapipe):
         assert sat_samples[i].time_utc[1] == t0_values[i]
         # Correct number of time steps are all NaN
         sat_sel = sat_samples[i].isel(x_geostationary=0, y_geostationary=0, channel=0)
-        
-        assert (np.isnan(sat_sel.values) == expected_missing_steps[i]).all(), (
-            f"{np.isnan(sat_sel.values)}!={expected_missing_steps[i]}"
-        )
+
+        assert (
+            np.isnan(sat_sel.values) == expected_missing_steps[i]
+        ).all(), f"{np.isnan(sat_sel.values)}!={expected_missing_steps[i]}"

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -14,7 +14,7 @@ def test_fill_1d_bool_gaps():
     x = np.array([0, 1, 0, 0, 1, 0, 1, 0])
     y = fill_1d_bool_gaps(x, max_gap=1, fill_ends=True).astype(int)
     assert (np.array([1, 1, 0, 0, 1, 1, 1, 1]) == y).all()
-    
+
 
 def test_select_time_slice_sat(sat_datapipe):
     data = next(iter(sat_datapipe))
@@ -22,7 +22,7 @@ def test_select_time_slice_sat(sat_datapipe):
     t0_datapipe = IterableWrapper(pd.to_datetime(data.time_utc.values)[3:6])
 
     # ----------- Check with history and forecast durations -----------
-    
+
     dp = SelectTimeSlice(
         sat_datapipe,
         t0_datapipe,
@@ -37,9 +37,9 @@ def test_select_time_slice_sat(sat_datapipe):
     for sat_sample, t0 in zip(sat_samples, t0_values):
         assert len(sat_sample.time_utc) == 3
         assert sat_sample.time_utc[1] == t0
-    
+
     # ------------------ Check again with intervals -------------------
-    
+
     dp = SelectTimeSlice(
         sat_datapipe,
         t0_datapipe,
@@ -55,7 +55,7 @@ def test_select_time_slice_sat(sat_datapipe):
         assert sat_sample.time_utc[1] == t0
 
     # -------------- Check with out of bounds selection ---------------
-    
+
     t_last = pd.to_datetime(data.time_utc.values[-1])
     t0_values = [
         t_last - timedelta(minutes=5),
@@ -82,23 +82,24 @@ def test_select_time_slice_sat(sat_datapipe):
         # Correct number of time steps are all NaN
         sat_sel = sat_sample.isel(x_geostationary=0, y_geostationary=0, channel=0)
         assert np.isnan(sat_sel.values).sum() == i
-        
-    # ------------------- Check with interpolation --------------------
-    
-    data_times = pd.to_datetime(data.time_utc.values)
-    t0_datapipe = IterableWrapper(data_times[[0,1,4,5]])
-    
-    missing_sat_data = data.sel(time_utc=data_times[[0,2,3,6]])
-    missing_sat_datapipe = IterableWrapper([missing_sat_data]).repeat(len(t0_datapipe))
-    
-    # For each sample the timestamps should be missing in this order
-    expected_missing_steps = np.array([
-        [True, False, False],
-        [False, False, False],
-        [False, True, True],
-        [True, True, False],
-    ])
 
+    # ------------------- Check with interpolation --------------------
+
+    data_times = pd.to_datetime(data.time_utc.values)
+    t0_datapipe = IterableWrapper(data_times[[0, 1, 4, 5]])
+
+    missing_sat_data = data.sel(time_utc=data_times[[0, 2, 3, 6]])
+    missing_sat_datapipe = IterableWrapper([missing_sat_data]).repeat(len(t0_datapipe))
+
+    # For each sample the timestamps should be missing in this order
+    expected_missing_steps = np.array(
+        [
+            [True, False, False],
+            [False, False, False],
+            [False, True, True],
+            [True, True, False],
+        ]
+    )
 
     dp = SelectTimeSlice(
         missing_sat_datapipe,


### PR DESCRIPTION
# Pull Request

- This adds functionality to `SelectTimeSliceIterDataPipe` to allow linear interpolation infilling of missing values up to a maximum number of consecutive time steps.
- Tests added for this functionality
- Added to pvnet production datapipe

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
