### PR TITLE
scattered updates for better lost of NWP sources

### DIFF
--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -501,7 +501,7 @@ class NWP(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensi
 
     # TODO change to nwp_path, as it could be a netcdf now.
     # https://github.com/openclimatefix/nowcasting_dataset/issues/582
-    nwp_zarr_path: str = Field(
+    nwp_zarr_path: Union[str, tuple[str], list[str]] = Field(
         "gs://solar-pv-nowcasting-data/NWP/UK_Met_Office/UKV__2018-01_to_2019-12__chunks__variable10__init_time1__step1__x548__y704__.zarr",  # noqa: E501
         description="The path which holds the NWP zarr.",
     )

--- a/ocf_datapipes/load/nwp/nwp.py
+++ b/ocf_datapipes/load/nwp/nwp.py
@@ -22,7 +22,7 @@ class OpenNWPIterDataPipe(IterDataPipe):
 
     def __init__(
         self,
-        zarr_path: Union[Path, str],
+        zarr_path: Union[Path, str, list[Path], list[str]],
         provider: str = "ukv",
     ):
         """

--- a/ocf_datapipes/load/nwp/providers/utils.py
+++ b/ocf_datapipes/load/nwp/providers/utils.py
@@ -19,7 +19,7 @@ def open_zarr_paths(zarr_path, time_dim="init_time") -> xr.Dataset:
             engine="zarr",
             concat_dim=time_dim,
             combine="nested",
-            chunks={},
+            chunks="auto",
         ).sortby(time_dim)
     else:
         nwp = xr.open_dataset(

--- a/ocf_datapipes/select/select_overlapping_time_slices.py
+++ b/ocf_datapipes/select/select_overlapping_time_slices.py
@@ -40,7 +40,7 @@ class SelectOverlappingTimeSliceIterDataPipe(IterDataPipe):
                 time_periods = intersection_of_multiple_dataframes_of_periods(list(set_of_pd_datas))
 
                 logger.debug(f"Found {len(time_periods)} time periods")
-                assert len(time_periods) > 0,  "\n".join([str(df) for df in set_of_pd_datas])
+                assert len(time_periods) > 0, "\n".join([str(df) for df in set_of_pd_datas])
 
                 yield time_periods
         else:
@@ -63,7 +63,7 @@ class SelectOverlappingTimeSliceIterDataPipe(IterDataPipe):
                     )
 
                     logger.debug(f"Found {len(time_periods)} time periods")
-                    assert len(time_periods) > 0,  "\n".join([str(df) for df in set_of_pd_datas])
+                    assert len(time_periods) > 0, "\n".join([str(df) for df in set_of_pd_datas])
 
                     self.time_periods_id[id] = time_periods
                     logger.debug(len(time_periods))

--- a/ocf_datapipes/select/select_overlapping_time_slices.py
+++ b/ocf_datapipes/select/select_overlapping_time_slices.py
@@ -40,7 +40,7 @@ class SelectOverlappingTimeSliceIterDataPipe(IterDataPipe):
                 time_periods = intersection_of_multiple_dataframes_of_periods(list(set_of_pd_datas))
 
                 logger.debug(f"Found {len(time_periods)} time periods")
-                assert len(time_periods) > 0
+                assert len(time_periods) > 0,  "\n".join([str(df) for df in set_of_pd_datas])
 
                 yield time_periods
         else:
@@ -63,7 +63,7 @@ class SelectOverlappingTimeSliceIterDataPipe(IterDataPipe):
                     )
 
                     logger.debug(f"Found {len(time_periods)} time periods")
-                    assert len(time_periods) > 0
+                    assert len(time_periods) > 0,  "\n".join([str(df) for df in set_of_pd_datas])
 
                     self.time_periods_id[id] = time_periods
                     logger.debug(len(time_periods))


### PR DESCRIPTION
# Pull Request

## Description

A few changes to use a list of zarrs as NWP inputs. Mostly minor changes except perhaps the `chunks="auto"` in open_mfdataset. I think this is what we want, and from some experiments it makes loading the dataset much faster. I was finding using `chunks={}` was taking too long to even allow it to complete


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
