### PR TITLE
NaNs no longer filled in-place to fix error on some systems architetures

### DIFF
--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -421,7 +421,7 @@ def fill_nans_in_pv(x: Union[xr.DataArray, xr.Dataset]):
 def _fill_nans_in_arrays(batch: dict):
     for k, v in batch.items():
         if isinstance(v, np.ndarray):
-            np.nan_to_num(v, copy=False, nan=0.0)
+            np.nan_to_num(v, copy=True, nan=0.0)
         # Recursion is included to reach NWP arrays in subdict
         elif isinstance(v, dict):
             _fill_nans_in_arrays(v)
@@ -434,7 +434,6 @@ def fill_nans_in_arrays(batch: NumpyBatch) -> NumpyBatch:
     """
     logger.info("Filling Nans with zeros")
     # This function is wrapped to avoid the logger info being duplicated on recursion
-    # Filling is done in-place
     _fill_nans_in_arrays(batch)
     return batch
 


### PR DESCRIPTION
# Pull Request

## Description

On some system architectures (Mac silicon specifically, but could apply to others too), the following error was being encountered when training PVNet:

```
File "/Users/chris/Dev/ocf/ocf_datapipes/ocf_datapipes/training/common.py", line 438, in fill_nans_in_arrays
    _fill_nans_in_arrays(batch)
  File "/Users/chris/Dev/ocf/ocf_datapipes/ocf_datapipes/training/common.py", line 424, in _fill_nans_in_arrays
    np.nan_to_num(v, copy=False, nan=0.0)
  File "/Users/chris/opt/miniconda3/envs/pvnet/lib/python3.9/site-packages/numpy/lib/type_check.py", line 517, in nan_to_num
    _nx.copyto(d, nan, where=idx_nan)
ValueError: assignment destination is read-only
This exception is thrown by __iter__ of MapperIterDataPipe(datapipe=AddSunPositionIterDataPipe, fn=fill_nans_in_arrays, input_col=None, output_col=None)
```

This PR updates the `_fill_nans_in_arrays` function to fix this error by filling nans via a copy instead of in-place. 

The implications of this change are possibly slightly less RAM efficiency during training in the presence of NaN values.

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
