### PR TITLE
fix batch unstacking for different NWP sources

### DIFF
--- a/ocf_datapipes/batch/merge_numpy_examples_to_batch.py
+++ b/ocf_datapipes/batch/merge_numpy_examples_to_batch.py
@@ -138,9 +138,12 @@ def unstack_np_batch_into_examples(batch: NumpyBatch):
 
                 # Unpack keys
                 nwp_sources = list(batch[BatchKey.nwp].keys())
-                nwp_keys = list(batch[BatchKey.nwp][nwp_sources[0]].keys())
+                
                 for nwp_source in nwp_sources:
                     nwp_source_batch: NWPNumpyBatch = {}
+                    
+                    # Keys can be different for each NWP source
+                    nwp_keys = list(batch[BatchKey.nwp][nwp_source].keys())
 
                     for nwp_key in nwp_keys:
                         nwp_source_batch[nwp_key] = extract_sample_from_batch(

--- a/ocf_datapipes/batch/merge_numpy_examples_to_batch.py
+++ b/ocf_datapipes/batch/merge_numpy_examples_to_batch.py
@@ -138,10 +138,10 @@ def unstack_np_batch_into_examples(batch: NumpyBatch):
 
                 # Unpack keys
                 nwp_sources = list(batch[BatchKey.nwp].keys())
-                
+
                 for nwp_source in nwp_sources:
                     nwp_source_batch: NWPNumpyBatch = {}
-                    
+
                     # Keys can be different for each NWP source
                     nwp_keys = list(batch[BatchKey.nwp][nwp_source].keys())
 

--- a/tests/batch/test_merge_numpy_examples_to_batch.py
+++ b/tests/batch/test_merge_numpy_examples_to_batch.py
@@ -26,8 +26,13 @@ def _single_batch_sample(fill_value):
         (8, 2, 24, 24), fill_value
     )  # shape: (time, variable, x, y)
     sample_nwp_ukv[NWPBatchKey.nwp_channel_names] = ["a", "b"]  # shape: (variable,)
+    
+    sample_nwp_ecmwf: NWPNumpyBatch = {}
+    sample_nwp_ecmwf[NWPBatchKey.nwp] = np.full(
+        (8, 4, 12, 12), fill_value
+    )  # shape: (time, variable, x, y)
 
-    sample[BatchKey.nwp] = {"ukv": sample_nwp_ukv}
+    sample[BatchKey.nwp] = {"ukv": sample_nwp_ukv, "ecmwf": sample_nwp_ecmwf,}
 
     return sample
 


### PR DESCRIPTION
# Pull Request

## Description

Fix `unstack_np_batch_into_examples()` for different NWP sources. Also extend test so it would have caught this.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
