### PR TITLE
Change PV loading to use label

### DIFF
--- a/tests/load/pv/test_load_pv.py
+++ b/tests/load/pv/test_load_pv.py
@@ -94,6 +94,7 @@ def test_open_both_from_nc():
     pv_file_passiv = PVFiles(
         pv_filename="tests/data/pv/passiv/test.nc",
         pv_metadata_filename="tests/data/pv/passiv/UK_PV_metadata.csv",
+        label="solar_sheffield_passiv",
     )
     pv.pv_files_groups = [pv_file, pv_file_passiv]
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes issue with PV loading relying on the filename, not the label that we give it.

Fixes #

## How Has This Been Tested?

Unit tests

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
