### PR TITLE
remove start-end datetime mixin

### DIFF
--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -179,41 +179,6 @@ class XYDimensionalNames(Base):
         return values
 
 
-class StartEndDatetimeMixin(Base):
-    """Mixin class to add start and end date"""
-
-    start_datetime: datetime = Field(
-        datetime(2020, 1, 1),
-        description="Load date from data sources from this date. "
-        "If None, this will get overwritten by InputData.start_date. ",
-    )
-    end_datetime: datetime = Field(
-        datetime(2021, 9, 1),
-        description="Load date from data sources up to this date. "
-        "If None, this will get overwritten by InputData.start_date. ",
-    )
-
-    @root_validator(skip_on_failure=True)
-    def check_start_and_end_datetime(cls, values):
-        """
-        Make sure start datetime is before end datetime
-        """
-
-        start_datetime = values["start_datetime"]
-        end_datetime = values["end_datetime"]
-
-        # check start datetime is less than end datetime
-        if start_datetime >= end_datetime:
-            message = (
-                f"Start datetime ({start_datetime}) "
-                f"should be less than end datetime ({end_datetime})"
-            )
-            logger.error(message)
-            assert Exception(message)
-
-        return values
-
-
 class PVFiles(BaseModel):
     """Model to hold pv file and metadata file"""
 
@@ -257,7 +222,7 @@ class WindFiles(BaseModel):
     label: str = Field(str, description="Label of where the wind data came from")
 
 
-class Wind(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensionalNames):
+class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
     """Wind configuration model"""
 
     wind_files_groups: List[WindFiles] = [WindFiles()]
@@ -302,7 +267,7 @@ class Wind(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimens
     )
 
 
-class PV(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensionalNames):
+class PV(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
     """PV configuration model"""
 
     pv_files_groups: List[PVFiles] = [PVFiles()]
@@ -378,7 +343,7 @@ class PV(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensio
         return v
 
 
-class Sensor(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensionalNames):
+class Sensor(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
     """PV configuration model"""
 
     sensor_image_size_meters_height: int = METERS_PER_ROI
@@ -568,7 +533,7 @@ class OpticalFlow(DataSourceMixin, TimeResolutionMixin):
     )
 
 
-class NWP(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin, XYDimensionalNames):
+class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
     """NWP configuration model"""
 
     # TODO change to nwp_path, as it could be a netcdf now.
@@ -624,7 +589,7 @@ class MultiNWP(Base):
         return self.__root__.items()
 
 
-class GSP(DataSourceMixin, StartEndDatetimeMixin, TimeResolutionMixin):
+class GSP(DataSourceMixin, TimeResolutionMixin):
     """GSP configuration model"""
 
     gsp_zarr_path: str = Field("gs://solar-pv-nowcasting-data/PV/GSP/v2/pv_gsp.zarr")

--- a/ocf_datapipes/load/pv/pv.py
+++ b/ocf_datapipes/load/pv/pv.py
@@ -44,8 +44,6 @@ class OpenPVFromNetCDFIterDataPipe(IterDataPipe):
             pv_files_group.inferred_metadata_filename for pv_files_group in pv.pv_files_groups
         ]
         self.labels = [pv_files_group.label for pv_files_group in pv.pv_files_groups]
-        self.start_datetime = pv.start_datetime
-        self.end_datetime = pv.end_datetime
 
     def __iter__(self):
         pv_array_list = []
@@ -53,8 +51,6 @@ class OpenPVFromNetCDFIterDataPipe(IterDataPipe):
             pv_array: xr.DataArray = load_everything_into_ram(
                 self.pv_power_filenames[i],
                 self.pv_metadata_filenames[i],
-                start_datetime=self.start_datetime,
-                end_datetime=self.end_datetime,
                 inferred_metadata_filename=self.inferred_metadata_filenames[i],
                 label=self.labels[i],
             )
@@ -70,8 +66,6 @@ def load_everything_into_ram(
     generation_filename,
     metadata_filename,
     inferred_metadata_filename: Optional[Union[str, Path]] = None,
-    start_datetime: Optional[datetime] = None,
-    end_datetime: Optional[datetime] = None,
     estimated_capacity_percentile: float = 100,
     label: Optional[str] = None,
 ) -> xr.DataArray:
@@ -81,8 +75,6 @@ def load_everything_into_ram(
         generation_filename: Filepath to the PV generation data
         metadata_filename: Filepath to the PV metadata
         inferred_metadata_filename: Filepath to inferred metadata
-        start_datetime: Data will be filtered to start at this datetime
-        end_datetime: Data will be filtered to end at this datetime
         estimated_capacity_percentile: Percentile used as the estimated capacity for each PV
             system. Recommended range is 99-100.
         label: Label of which provider the PV data came from
@@ -94,8 +86,6 @@ def load_everything_into_ram(
     # Load pd.DataFrame of power and pd.Series of capacities:
     df_gen, estimated_capacities = _load_pv_generation_and_capacity(
         generation_filename,
-        start_date=start_datetime,
-        end_date=end_datetime,
         estimated_capacity_percentile=estimated_capacity_percentile,
     )
 
@@ -131,8 +121,6 @@ def load_everything_into_ram(
 
 def _load_pv_generation_and_capacity(
     filename: Union[str, Path],
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None,
     estimated_capacity_percentile: float = 99,
     label: Optional[str] = None,
 ) -> tuple[pd.DataFrame, pd.Series]:
@@ -142,8 +130,6 @@ def _load_pv_generation_and_capacity(
 
     Args:
         filename: The filename (netcdf) of the PV data to load
-        start_date: Start date to load from
-        end_date: End of period to load
         estimated_capacity_percentile: Percentile used as the estimated capacity for each PV
             system. Recommended range is 99-100.
         label: Label of which provider the PV data came from
@@ -153,7 +139,7 @@ def _load_pv_generation_and_capacity(
         Series of PV system estimated capacities in watts
     """
 
-    _log.info(f"Loading solar PV power data from {filename} from {start_date=} to {end_date=}.")
+    _log.info(f"Loading solar PV power data from {filename}.")
 
     # Load data in a way that will work in the cloud and locally:
     if ".parquet" in str(filename):
@@ -196,9 +182,6 @@ def _load_pv_generation_and_capacity(
 
     _log.info("Loaded solar PV power data and converting to pandas.")
     estimated_capacities = df_gen.quantile(estimated_capacity_percentile / 100)
-
-    # Filter to given time
-    df_gen = df_gen.loc[slice(start_date, end_date)]
 
     # Remove systems with no generation data
     mask = estimated_capacities > 0

--- a/ocf_datapipes/load/pv/pv.py
+++ b/ocf_datapipes/load/pv/pv.py
@@ -1,7 +1,6 @@
 """Datapipe and utils to load PV data from NetCDF for training"""
 import io
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
 

--- a/ocf_datapipes/load/wind/wind.py
+++ b/ocf_datapipes/load/wind/wind.py
@@ -1,9 +1,8 @@
 """Datapipe and utils to load PV data from NetCDF for training"""
 import io
 import logging
-from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 import fsspec
 import numpy as np

--- a/ocf_datapipes/load/wind/wind.py
+++ b/ocf_datapipes/load/wind/wind.py
@@ -40,8 +40,6 @@ class OpenWindFromNetCDFIterDataPipe(IterDataPipe):
         self.wind_metadata_filenames = [
             wind_files_group.wind_metadata_filename for wind_files_group in wind.wind_files_groups
         ]
-        self.start_datetime = wind.start_datetime
-        self.end_datetime = wind.end_datetime
 
     def __iter__(self):
         wind_array_list = []
@@ -49,8 +47,6 @@ class OpenWindFromNetCDFIterDataPipe(IterDataPipe):
             wind_array: xr.DataArray = load_everything_into_ram(
                 self.wind_power_filenames[i],
                 self.wind_metadata_filenames[i],
-                start_datetime=self.start_datetime,
-                end_datetime=self.end_datetime,
             )
             wind_array_list.append(wind_array)
 
@@ -87,8 +83,6 @@ def _load_wind_metadata(filename: str) -> pd.DataFrame:
 def load_everything_into_ram(
     generation_filename,
     metadata_filename,
-    start_datetime: Optional[datetime] = None,
-    end_datetime: Optional[datetime] = None,
     estimated_capacity_percentile: float = 100,
 ) -> xr.DataArray:
     """Load Wind data into xarray DataArray in RAM.
@@ -96,8 +90,6 @@ def load_everything_into_ram(
     Args:
         generation_filename: Filepath to the Wind generation data
         metadata_filename: Filepath to the Wind metadata
-        start_datetime: Data will be filtered to start at this datetime
-        end_datetime: Data will be filtered to end at this datetime
         estimated_capacity_percentile: Percentile used as the estimated capacity for each PV
             system. Recommended range is 99-100.
     """
@@ -107,8 +99,6 @@ def load_everything_into_ram(
     # Load pd.DataFrame of power and pd.Series of capacities:
     df_gen, estimated_capacities = _load_wind_generation_and_capacity(
         generation_filename,
-        start_date=start_datetime,
-        end_date=end_datetime,
         estimated_capacity_percentile=estimated_capacity_percentile,
     )
     # Drop systems where all values are NaN
@@ -139,8 +129,6 @@ def load_everything_into_ram(
 
 def _load_wind_generation_and_capacity(
     filename: Union[str, Path],
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None,
     estimated_capacity_percentile: float = 99,
 ) -> tuple[pd.DataFrame, pd.Series]:
     """Load the PV data and estimates the capacity for each PV system.
@@ -149,8 +137,6 @@ def _load_wind_generation_and_capacity(
 
     Args:
         filename: The filename (netcdf) of the wind data to load
-        start_date: Start date to load from
-        end_date: End of period to load
         estimated_capacity_percentile: Percentile used as the estimated capacity for each PV
             system. Recommended range is 99-100.
 
@@ -159,7 +145,7 @@ def _load_wind_generation_and_capacity(
         Series of PV system estimated capacities in watts
     """
 
-    _log.info(f"Loading wind power data from {filename} from {start_date=} to {end_date=}.")
+    _log.info(f"Loading wind power data from {filename}.")
 
     with fsspec.open(filename, mode="rb") as file:
         file_bytes = file.read()
@@ -175,8 +161,7 @@ def _load_wind_generation_and_capacity(
 
     _log.info("Loaded wind PV power data and converting to pandas.")
     estimated_capacities = df_gen.quantile(estimated_capacity_percentile / 100)
-    # Filter to given time
-    df_gen = df_gen.loc[slice(start_date, end_date)]
+
     # Remove systems with no generation data
     mask = estimated_capacities > 0
     estimated_capacities = estimated_capacities[mask]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,10 +97,7 @@ def passiv_datapipe():
     filename = f"{_top_test_directory}/data/pv/passiv/test.nc"
     filename_metadata = f"{_top_test_directory}/data/pv/passiv/UK_PV_metadata.csv"
 
-    pv = PV(
-        start_datetime=datetime(2018, 1, 1),
-        end_datetime=datetime(2023, 1, 1),
-    )
+    pv = PV()
     pv_file = PVFiles(
         pv_filename=str(filename),
         pv_metadata_filename=str(filename_metadata),
@@ -116,10 +113,7 @@ def pvoutput_datapipe():
     filename = f"{_top_test_directory}/data/pv/pvoutput/test.nc"
     filename_metadata = f"{_top_test_directory}/data/pv/pvoutput/UK_PV_metadata.csv"
 
-    pv = PV(
-        start_datetime=datetime(2018, 1, 1),
-        end_datetime=datetime(2023, 1, 1),
-    )
+    pv = PV()
     pv_file = PVFiles(
         pv_filename=str(filename),
         pv_metadata_filename=str(filename_metadata),

--- a/tests/data/configs/test.yaml
+++ b/tests/data/configs/test.yaml
@@ -27,8 +27,6 @@ input_data:
     wind_image_size_meters_height: 10000000
     wind_image_size_meters_width: 10000000
     n_wind_systems_per_example: 1
-    start_datetime: "2010-01-01 00:00:00"
-    end_datetime: "2030-01-01 00:00:00"
     wind_ml_ids: []
   pv:
     pv_files_groups:
@@ -42,8 +40,6 @@ input_data:
     pv_image_size_meters_height: 10000000
     pv_image_size_meters_width: 10000000
     n_pv_systems_per_example: 32
-    start_datetime: "2010-01-01 00:00:00"
-    end_datetime: "2030-01-01 00:00:00"
     pv_ml_ids: []
   satellite:
     satellite_channels:

--- a/tests/data/configs/wind_test.yaml
+++ b/tests/data/configs/wind_test.yaml
@@ -27,8 +27,6 @@ input_data:
     pv_image_size_meters_height: 10000000
     pv_image_size_meters_width: 10000000
     n_pv_systems_per_example: 32
-    start_datetime: "2010-01-01 00:00:00"
-    end_datetime: "2030-01-01 00:00:00"
     pv_ml_ids: []
   satellite:
     satellite_channels:

--- a/tests/load/pv/test_load_pv.py
+++ b/tests/load/pv/test_load_pv.py
@@ -35,10 +35,7 @@ def test_open_india_from_nc():
 
 
 def test_open_passiv_from_parquet(pv_parquet_file):
-    pv = PV(
-        start_datetime=datetime(2018, 1, 1),
-        end_datetime=datetime(2023, 1, 1),
-    )
+    pv = PV()
     pv_file = PVFiles(
         pv_filename=pv_parquet_file,
         pv_metadata_filename="tests/data/pv/passiv/UK_PV_metadata.csv",


### PR DESCRIPTION
# Pull Request

## Description

Remove the start/end time mixin as it is generally unused. The preferred way to limit the time range of samples is something like [this](https://github.com/openclimatefix/ocf_datapipes/blob/287be67636f1364a6db4d9d45b3799b6aea0eb8e/ocf_datapipes/training/common.py#L612)

Note:

Initial discussions around this were that this might be less memory efficient, and that we'd be keeping unused data around by not filtering. However, based on [this stack overflow question](https://stackoverflow.com/questions/50195197/reduce-memory-usage-when-slicing-numpy-arrays), I'm not sure we were even freeing up memory with the slicing we were using previously


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
