### PR TITLE
Move hard-coded dropout and staleness values into configs

### DIFF
--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -136,7 +136,7 @@ class DropoutMixin(Base):
         "negative or zero.",
     )
 
-    dropout_fraction: int = Field(0, description="Chance of dropout being applied to each sample")
+    dropout_fraction: float = Field(0, description="Chance of dropout being applied to each sample")
 
     @validator("dropout_timedeltas_minutes")
     def dropout_timedeltas_minutes_negative(cls, v):
@@ -165,8 +165,8 @@ class SystemDropoutMixin(Base):
 
     # The degree of system dropout for each returned sample will be randomly drawn from
     # the range [system_dropout_fraction_min, system_dropout_fraction_max]
-    system_dropout_fraction_min: int = Field(0, description="Min chance of system dropout")
-    system_dropout_fraction_max: int = Field(0, description="Max chance of system dropout")
+    system_dropout_fraction_min: float = Field(0, description="Min chance of system dropout")
+    system_dropout_fraction_max: float = Field(0, description="Max chance of system dropout")
 
 
 class TimeResolutionMixin(Base):

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -167,6 +167,19 @@ class SystemDropoutMixin(Base):
     # the range [system_dropout_fraction_min, system_dropout_fraction_max]
     system_dropout_fraction_min: float = Field(0, description="Min chance of system dropout")
     system_dropout_fraction_max: float = Field(0, description="Max chance of system dropout")
+    
+    @validator("system_dropout_fraction_min", "system_dropout_fraction_max")
+    def validate_system_dropout_fractions(cls, v):
+        assert 0 <= v <= 1
+        return v
+    
+    @root_validator()
+    def validate_system_dropout_fraction_range(cls, values):
+        assert (
+            values["system_dropout_fraction_min"] 
+            <= values["system_dropout_fraction_max"]
+        )
+        return values
 
 
 class TimeResolutionMixin(Base):

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -170,11 +170,13 @@ class SystemDropoutMixin(Base):
 
     @validator("system_dropout_fraction_min", "system_dropout_fraction_max")
     def validate_system_dropout_fractions(cls, v):
+        """Validate dropout fraction values"""
         assert 0 <= v <= 1
         return v
 
     @root_validator()
     def validate_system_dropout_fraction_range(cls, values):
+        """Ensure positive dropout fraction range"""
         assert values["system_dropout_fraction_min"] <= values["system_dropout_fraction_max"]
         return values
 

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -136,10 +136,7 @@ class DropoutMixin(Base):
         "negative or zero.",
     )
 
-    dropout_fraction: int = Field(
-        0,
-        description="Chance of dropout being applied to each sample"
-    )
+    dropout_fraction: int = Field(0, description="Chance of dropout being applied to each sample")
 
     @validator("dropout_timedeltas_minutes")
     def dropout_timedeltas_minutes_negative(cls, v):
@@ -148,13 +145,13 @@ class DropoutMixin(Base):
             for m in v:
                 assert m <= 0
         return v
-    
+
     @validator("dropout_fraction")
     def dropout_fraction_valid(cls, v):
         """Validate 'dropout_fraction'"""
-        assert 0<=v<=1
+        assert 0 <= v <= 1
         return v
-    
+
 
 class SystemDropoutMixin(Base):
     """Mixin class, to add independent system dropout"""
@@ -166,16 +163,10 @@ class SystemDropoutMixin(Base):
         "values randomly selected from this list.",
     )
 
-    # The degree of system dropout for each returned sample will be randomly drawn from 
+    # The degree of system dropout for each returned sample will be randomly drawn from
     # the range [system_dropout_fraction_min, system_dropout_fraction_max]
-    system_dropout_fraction_min: int = Field(
-        0,
-        description="Min chance of system dropout"
-    )
-    system_dropout_fraction_max: int = Field(
-        0,
-        description="Max chance of system dropout"
-    )
+    system_dropout_fraction_min: int = Field(0, description="Min chance of system dropout")
+    system_dropout_fraction_max: int = Field(0, description="Max chance of system dropout")
 
 
 class TimeResolutionMixin(Base):

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -167,18 +167,15 @@ class SystemDropoutMixin(Base):
     # the range [system_dropout_fraction_min, system_dropout_fraction_max]
     system_dropout_fraction_min: float = Field(0, description="Min chance of system dropout")
     system_dropout_fraction_max: float = Field(0, description="Max chance of system dropout")
-    
+
     @validator("system_dropout_fraction_min", "system_dropout_fraction_max")
     def validate_system_dropout_fractions(cls, v):
         assert 0 <= v <= 1
         return v
-    
+
     @root_validator()
     def validate_system_dropout_fraction_range(cls, values):
-        assert (
-            values["system_dropout_fraction_min"] 
-            <= values["system_dropout_fraction_max"]
-        )
+        assert values["system_dropout_fraction_min"] <= values["system_dropout_fraction_max"]
         return values
 
 

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -295,7 +295,7 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
     )
 
 
-class PV(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
+class PV(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin):
     """PV configuration model"""
 
     pv_files_groups: List[PVFiles] = [PVFiles()]
@@ -582,7 +582,8 @@ class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin
     max_staleness_minutes: int = Field(
         None,
         description="Sets a limit on how stale an NWP init time is allowed to be whilst still being"
-        " used to construct an example",
+        " used to construct an example. If set to None, then the max staleness is set according to"
+        " the maximum forecast horizon of the NWP and the requested forecast length.",
     )
 
     @validator("nwp_provider")

--- a/ocf_datapipes/select/apply_pv_dropout.py
+++ b/ocf_datapipes/select/apply_pv_dropout.py
@@ -1,7 +1,7 @@
 """Convert NWP data to the target time with dropout"""
 import logging
 from datetime import timedelta
-from typing import List, Union
+from typing import List, Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -22,67 +22,84 @@ class ApplyPVDropoutIterDataPipe(IterDataPipe):
     def __init__(
         self,
         source_datapipe: IterDataPipe,
-        system_dropout_fractions: List[float],
-        system_dropout_timedeltas: List[timedelta],
+        min_frac: float,
+        max_frac: float,
+        system_dropout_timedeltas: Optional[List[timedelta]],
     ):
         """Apply PV system dropout to mimic production
 
-        Systems have independent delay times. Systems may also completely drop out.
+        Systems have independent delay times. Systems may also completely drop out. 
+        
+        For each yielded sample, a dropout fraction will be randomly chosen from the range 
+        [min_frac, max_frac]. This random fraction will be used as the chance of dropout for each 
+        PV system in the sample. Using a list instead of a single value allows us to avoid
+        overfitting to the fraction of dropped out systems.
 
         Args:
             source_datapipe: Datapipe emitting an Xarray Dataset with time_utc indexer.
-            system_dropout_fractions: List of possible system dropout fractions to apply to each
-                sample. For each yielded sample, one of these fractions will be chosen and used to
-                dropout each PV system. Using a list instead of a single value allows us to avoid
-                overfitting to the fraction of dropped out systems.
+            min_frac: The minimum chance for each system to be dropped out in a sample
+            max_frac: The maximum chance for each system to be dropped out in a sample
             system_dropout_timedeltas: List of timedeltas. We randomly select the delay for each PV
                 system from this list. These should be negative timedeltas w.r.t the last time_utc
                 value of the xarray data.
         """
         self.source_datapipe = source_datapipe
-        self.system_dropout_fractions = system_dropout_fractions
+        self.min_frac = min_frac
+        self.max_frac = max_frac
         self.system_dropout_timedeltas = system_dropout_timedeltas
+    
+        if system_dropout_timedeltas is not None:
+            assert (
+                len(system_dropout_timedeltas) >= 1
+            ), "Must include list of relative dropout timedeltas"
 
-        assert (
-            len(system_dropout_timedeltas) >= 1
-        ), "Must include list of relative dropout timedeltas"
+            assert all(
+                [t <= timedelta(minutes=0) for t in system_dropout_timedeltas]
+            ), f"dropout timedeltas must be negative: {system_dropout_timedeltas}"
 
         assert all(
-            [t <= timedelta(minutes=0) for t in system_dropout_timedeltas]
-        ), f"dropout timedeltas must be negative: {system_dropout_timedeltas}"
-
-        assert all(
-            [0 <= f <= 1 for f in system_dropout_fractions]
-        ), "dropout fractions must be in open range (0, 1)"
+            [0 <= f <= 1 for f in [min_frac, max_frac]]
+        ), "The min and max dropout fractions must be in open range (0, 1)"
+        
+        assert min_frac<=max_frac, "Min dropout fraction <= maximum dropout fraction"
 
     def __iter__(self) -> Union[xr.DataArray, xr.Dataset]:
         """Iterate through Xarray dataset using dropout"""
 
         for xr_data in self.source_datapipe:
+            
             # Assign these values for convenience
             t0 = pd.Timestamp(xr_data.time_utc.values[-1])
             n_systems = len(xr_data.pv_system_id)
+            
+            if not (self.min_frac==self.max_frac==0):
+                # Apply PV system dropout - individual systems are dropped out
 
-            # Apply PV system dropout - individual systems are dropped out
+                # Don't want fraction of dropped out system to be the same in each sample
+                # This might lead to overfitting. Instead vary it
+                dropout_p = np.random.uniform(low=self.min_frac, high=self.max_frac)
 
-            # Don't want fraction of dropped out system to be the same in each sample
-            # This might lead to overfitting. Instead vary it
-            dropout_p = np.random.choice(self.system_dropout_fractions)
+                system_mask = xr.zeros_like(xr_data.pv_system_id, dtype=bool)
+                system_mask.values[:] = np.random.uniform(size=n_systems) >= dropout_p
 
-            system_mask = xr.zeros_like(xr_data.pv_system_id, dtype=bool)
-            system_mask.values[:] = np.random.uniform(size=n_systems) >= dropout_p
+                xr_data = xr_data.where(system_mask)
+            
+            if self.system_dropout_timedeltas is not None:
 
-            # Apply independent delay to each PV system
-            delay_mask = xr.zeros_like(xr_data, dtype=bool)
+                # Apply independent delay to each PV system
+                delay_mask = xr.zeros_like(xr_data, dtype=bool)
 
-            last_available_times = xr.zeros_like(xr_data.pv_system_id, dtype=xr_data.time_utc.dtype)
-            last_available_times.values[:] = t0 + np.random.choice(
-                self.system_dropout_timedeltas, size=n_systems
-            )
+                last_available_times = xr.zeros_like(
+                    xr_data.pv_system_id, 
+                    dtype=xr_data.time_utc.dtype
+                )
+                last_available_times.values[:] = t0 + np.random.choice(
+                    self.system_dropout_timedeltas, size=n_systems
+                )
 
-            delay_mask = xr_data.time_utc <= last_available_times
+                delay_mask = xr_data.time_utc <= last_available_times
 
-            # Apply masking
-            xr_data = xr_data.where(system_mask).where(delay_mask)
+                # Apply masking
+                xr_data = xr_data.where(delay_mask)
 
             yield xr_data

--- a/ocf_datapipes/select/apply_standard_dropout.py
+++ b/ocf_datapipes/select/apply_standard_dropout.py
@@ -30,9 +30,7 @@ class DrawDropoutTimeIterDataPipe(IterDataPipe):
         self.dropout_timedeltas = dropout_timedeltas
         self.dropout_frac = dropout_frac
         if dropout_timedeltas is not None:
-            assert len(dropout_timedeltas) >= 1, (
-                "Must include list of relative dropout timedeltas"
-            )
+            assert len(dropout_timedeltas) >= 1, "Must include list of relative dropout timedeltas"
             assert all(
                 [t < timedelta(minutes=0) for t in dropout_timedeltas]
             ), "dropout timedeltas must be negative"

--- a/ocf_datapipes/select/find_contiguous_t0_time_periods.py
+++ b/ocf_datapipes/select/find_contiguous_t0_time_periods.py
@@ -106,15 +106,15 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
                 pd.Timedelta(xr_data["step"].max().item()) - self.forecast_duration
             )
 
-            # If max_staleness is set to None we set it based on the max step ahead of the input 
+            # If max_staleness is set to None we set it based on the max step ahead of the input
             # forecast data
             if self.max_staleness is None:
                 max_staleness = possible_max_staleness
             else:
-                # Make sure the max acceptable staleness isn't longer than the max possible
+                # Make sure the max acceptable staleness isn't longer than the max possible
                 assert self.max_staleness <= possible_max_staleness
                 max_staleness = self.max_staleness
-            
+
             contiguous_time_periods = find_contiguous_t0_periods_nwp(
                 datetimes=pd.DatetimeIndex(xr_data[self.time_dim]),
                 history_duration=self.history_duration,

--- a/ocf_datapipes/select/find_contiguous_t0_time_periods.py
+++ b/ocf_datapipes/select/find_contiguous_t0_time_periods.py
@@ -99,7 +99,7 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
         """Calculate contiguous time periods and return a dataframe containing them"""
         for xr_data in self.source_datapipe:
             logger.debug("Getting contiguous NWP t0 time periods")
-            assert "step" in xr_data
+            assert "step" in xr_data.coords
             # It is possible to use up to this amount of max staleness for the dataset and slice
             # Required
             possible_max_staleness = (

--- a/ocf_datapipes/select/find_contiguous_t0_time_periods.py
+++ b/ocf_datapipes/select/find_contiguous_t0_time_periods.py
@@ -1,6 +1,7 @@
 """Get contiguous time periods for training"""
 import logging
 from datetime import timedelta
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -68,9 +69,10 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
         self,
         source_datapipe: IterDataPipe,
         history_duration: timedelta,
-        max_staleness: timedelta = timedelta(minutes=0),
-        max_dropout: timedelta = timedelta(minutes=0),
-        time_dim: str = "init_time_utc",
+        forecast_duration: timedelta,
+        max_staleness: Optional[timedelta] = None,
+        max_dropout: Optional[timedelta] = timedelta(minutes=0),
+        time_dim: Optional[str] = "init_time_utc",
     ):
         """
         Get contiguous time periods for use in determing t0 times for training
@@ -78,6 +80,7 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
         Args:
             source_datapipe: Datapipe emitting a Xarray dataset
             history_duration: Length of the historical slice used for a sample
+            forecast_duration: Length of the forecast slice used for a sample
             max_staleness: Up to how long after an NWP forecast init_time are we willing to use the
                 forecast. Each init time will only be used up to this t0 time regardless of the
                 forecast valid time.
@@ -87,6 +90,7 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
         """
         self.source_datapipe = source_datapipe
         self.history_duration = history_duration
+        self.forecast_duration = forecast_duration
         self.max_staleness = max_staleness
         self.max_dropout = max_dropout
         self.time_dim = time_dim
@@ -95,10 +99,26 @@ class FindContiguousT0TimePeriodsNWPIterDataPipe(IterDataPipe):
         """Calculate contiguous time periods and return a dataframe containing them"""
         for xr_data in self.source_datapipe:
             logger.debug("Getting contiguous NWP t0 time periods")
+            assert "step" in xr_data
+            # It is possible to use up to this amount of max staleness for the dataset and slice
+            # Required
+            possible_max_staleness = (
+                pd.Timedelta(xr_data["step"].max().item()) - self.forecast_duration
+            )
+
+            # If max_staleness is set to None we set it based on the max step ahead of the input 
+            # forecast data
+            if self.max_staleness is None:
+                max_staleness = possible_max_staleness
+            else:
+                # Make sure the max acceptable staleness isn't longer than the max possible
+                assert self.max_staleness <= possible_max_staleness
+                max_staleness = self.max_staleness
+            
             contiguous_time_periods = find_contiguous_t0_periods_nwp(
                 datetimes=pd.DatetimeIndex(xr_data[self.time_dim]),
                 history_duration=self.history_duration,
-                max_staleness=self.max_staleness,
+                max_staleness=max_staleness,
                 max_dropout=self.max_dropout,
             )
             yield contiguous_time_periods

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -111,10 +111,10 @@ def open_and_return_datapipes(
         gsp_datapipe = OpenGSP(
             gsp_pv_power_zarr_path=configuration.input_data.gsp.gsp_zarr_path
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(
-                minutes=configuration.input_data.gsp.time_resolution_minutes
+            sample_period_duration=minutes(
+                configuration.input_data.gsp.time_resolution_minutes
             ),
-            history_duration=timedelta(minutes=configuration.input_data.gsp.history_minutes),
+            history_duration=minutes(configuration.input_data.gsp.history_minutes),
         )
 
         used_datapipes["gsp"] = gsp_datapipe
@@ -132,7 +132,7 @@ def open_and_return_datapipes(
                 .filter_channels(nwp_conf.nwp_channels)
                 .add_t0_idx_and_sample_period_duration(
                     sample_period_duration=timedelta(hours=1),
-                    history_duration=timedelta(minutes=nwp_conf.history_minutes),
+                    history_duration=minutes(nwp_conf.history_minutes),
                 )
             )
 
@@ -142,11 +142,11 @@ def open_and_return_datapipes(
             OpenSatellite(configuration.input_data.satellite.satellite_zarr_path)
             .filter_channels(configuration.input_data.satellite.satellite_channels)
             .add_t0_idx_and_sample_period_duration(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.satellite.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.satellite.time_resolution_minutes
                 ),
-                history_duration=timedelta(
-                    minutes=configuration.input_data.satellite.history_minutes
+                history_duration=minutes(
+                    configuration.input_data.satellite.history_minutes
                 ),
             )
         )
@@ -158,11 +158,11 @@ def open_and_return_datapipes(
         sat_hrv_datapipe = OpenSatellite(
             configuration.input_data.hrvsatellite.hrvsatellite_zarr_path
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(
-                minutes=configuration.input_data.hrvsatellite.time_resolution_minutes
+            sample_period_duration=minutes(
+                configuration.input_data.hrvsatellite.time_resolution_minutes
             ),
-            history_duration=timedelta(
-                minutes=configuration.input_data.hrvsatellite.history_minutes
+            history_duration=minutes(
+                configuration.input_data.hrvsatellite.history_minutes
             ),
         )
 
@@ -173,10 +173,10 @@ def open_and_return_datapipes(
         pv_datapipe = OpenPVFromNetCDF(
             pv=configuration.input_data.pv
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(
-                minutes=configuration.input_data.pv.time_resolution_minutes
+            sample_period_duration=minutes(
+                configuration.input_data.pv.time_resolution_minutes
             ),
-            history_duration=timedelta(minutes=configuration.input_data.pv.history_minutes),
+            history_duration=minutes(configuration.input_data.pv.history_minutes),
         )
 
         used_datapipes["pv"] = pv_datapipe
@@ -186,10 +186,10 @@ def open_and_return_datapipes(
         wind_datapipe = OpenWindFromNetCDF(
             wind=configuration.input_data.wind
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(
-                minutes=configuration.input_data.wind.time_resolution_minutes
+            sample_period_duration=minutes(
+                configuration.input_data.wind.time_resolution_minutes
             ),
-            history_duration=timedelta(minutes=configuration.input_data.wind.history_minutes),
+            history_duration=minutes(configuration.input_data.wind.history_minutes),
         )
 
         used_datapipes["wind"] = wind_datapipe
@@ -199,10 +199,10 @@ def open_and_return_datapipes(
         sensor_datapipe = OpenAWOSFromNetCDF(
             configuration.input_data.sensor
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(
-                minutes=configuration.input_data.sensor.time_resolution_minutes
+            sample_period_duration=minutes(
+                configuration.input_data.sensor.time_resolution_minutes
             ),
-            history_duration=timedelta(minutes=configuration.input_data.sensor.history_minutes),
+            history_duration=minutes(configuration.input_data.sensor.history_minutes),
         )
 
         used_datapipes["sensor"] = sensor_datapipe
@@ -246,11 +246,11 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
             nwp_source = key.removeprefix("nwp/")
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
                 sample_period_duration=timedelta(hours=3),  # Init times are 3 hours apart
-                history_duration=timedelta(
-                    minutes=configuration.input_data.nwp[nwp_source].history_minutes
+                history_duration=minutes(
+                    configuration.input_data.nwp[nwp_source].history_minutes
                 ),
-                forecast_duration=timedelta(
-                    minutes=configuration.input_data.nwp[nwp_source].forecast_minutes
+                forecast_duration=minutes(
+                    configuration.input_data.nwp[nwp_source].forecast_minutes
                 ),
                 time_dim="init_time_utc",
             )
@@ -258,64 +258,64 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
 
         if "sat" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.satellite.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.satellite.time_resolution_minutes
                 ),
-                history_duration=timedelta(
-                    minutes=configuration.input_data.satellite.history_minutes
+                history_duration=minutes(
+                    configuration.input_data.satellite.history_minutes
                 ),
-                forecast_duration=timedelta(minutes=0),
+                forecast_duration=minutes(0),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
 
         if "hrv" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.hrvsatellite.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.hrvsatellite.time_resolution_minutes
                 ),
-                history_duration=timedelta(
-                    minutes=configuration.input_data.hrvsatellite.history_minutes
+                history_duration=minutes(
+                    configuration.input_data.hrvsatellite.history_minutes
                 ),
-                forecast_duration=timedelta(minutes=0),
+                forecast_duration=minutes(0),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
 
         if "pv" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.pv.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.pv.time_resolution_minutes
                 ),
-                history_duration=timedelta(minutes=configuration.input_data.pv.history_minutes),
-                forecast_duration=timedelta(minutes=configuration.input_data.pv.forecast_minutes),
+                history_duration=minutes(configuration.input_data.pv.history_minutes),
+                forecast_duration=minutes(configuration.input_data.pv.forecast_minutes),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
         if "wind" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.wind.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.wind.time_resolution_minutes
                 ),
-                history_duration=timedelta(minutes=configuration.input_data.wind.history_minutes),
-                forecast_duration=timedelta(minutes=configuration.input_data.wind.forecast_minutes),
+                history_duration=minutes(configuration.input_data.wind.history_minutes),
+                forecast_duration=minutes(configuration.input_data.wind.forecast_minutes),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
         if "gsp" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.gsp.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.gsp.time_resolution_minutes
                 ),
-                history_duration=timedelta(minutes=configuration.input_data.gsp.history_minutes),
-                forecast_duration=timedelta(minutes=configuration.input_data.gsp.forecast_minutes),
+                history_duration=minutes(configuration.input_data.gsp.history_minutes),
+                forecast_duration=minutes(configuration.input_data.gsp.forecast_minutes),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
 
         if "sensor" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.sensor.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.sensor.time_resolution_minutes
                 ),
-                history_duration=timedelta(minutes=configuration.input_data.sensor.history_minutes),
-                forecast_duration=timedelta(
-                    minutes=configuration.input_data.sensor.forecast_minutes
+                history_duration=minutes(configuration.input_data.sensor.history_minutes),
+                forecast_duration=minutes(
+                    configuration.input_data.sensor.forecast_minutes
                 ),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
@@ -558,8 +558,8 @@ def _get_datapipes_dict(
 
     if production:
         datapipes_dict["gsp"] = OpenGSPFromDatabase().add_t0_idx_and_sample_period_duration(
-            sample_period_duration=timedelta(minutes=config.input_data.gsp.time_resolution_minutes),
-            history_duration=timedelta(minutes=config.input_data.gsp.history_minutes),
+            sample_period_duration=minutes(config.input_data.gsp.time_resolution_minutes),
+            history_duration=minutes(config.input_data.gsp.history_minutes),
         )
         if "sat" in datapipes_dict:
             datapipes_dict["sat"] = datapipes_dict["sat"].map(production_sat_scale)
@@ -617,9 +617,6 @@ def construct_loctime_pipelines(
         configuration=config,
         key_for_t0=core_key,
         shuffle=True,
-        nwp_max_dropout_minutes=180,
-        # Sometimes the forecast is only 4/day so 6 hour intervals - then we add 3-hour dropout
-        nwp_max_staleness_minutes=60 * 9,
     )
 
     return location_pipe, t0_datapipe
@@ -632,6 +629,14 @@ def minutes(num_mins: int):
         num_mins: Minutes timedelta.
     """
     return timedelta(minutes=num_mins)
+
+
+def minutes_list_to_timedeltas(list_ints):
+    """Utility function to convert list of dropout timedelta minutes ints to list of timedeltas"""
+    if list_ints is None:
+        return list_ints
+    else:
+        return [minutes(m) for m in list_ints] 
 
 
 def slice_datapipes_by_time(
@@ -681,27 +686,39 @@ def slice_datapipes_by_time(
 
     get_t0_datapipe = DatapipeKeyForker(fork_keys, t0_datapipe)
 
+    # Satelite and HRV satellite should drop out simultaneously when they dropout
     if "sat" in datapipes_dict or "hrv" in datapipes_dict:
+        if "sat" in datapipes_dict:
+            conf_sathrv = conf_in.satellite
+        else:
+            conf_sathrv = conf_in.hrvsatellite
+
+        dropout_timedeltas = minutes_list_to_timedeltas(conf_sathrv.dropout_timedeltas_minutes)
+
         sat_and_hrv_dropout_kwargs = dict(
             # Satellite is either 30 minutes or 60 minutes delayed in production.
             # Match during training
-            dropout_timedeltas=[minutes(-60), minutes(-30)],
-            dropout_frac=0 if production else 1.0,
+            dropout_timedeltas=dropout_timedeltas,
+            dropout_frac=0 if production else conf_sathrv.dropout_fraction,
         )
 
-        sat_delay = minutes(-configuration.input_data.satellite.live_delay_minutes)
+        sat_delay = minutes(-conf_sathrv.satellite.live_delay_minutes)
 
     if "nwp" in datapipes_dict:
         # NWP is nested in the dict
         for nwp_key, dp in datapipes_dict["nwp"].items():
+
+            dropout_timedeltas = minutes_list_to_timedeltas(
+                conf_in.nwp[nwp_key].dropout_timedeltas_minutes
+            )
+
             datapipes_dict["nwp"][nwp_key] = dp.select_time_slice_nwp(
                 t0_datapipe=get_t0_datapipe(f"nwp/{nwp_key}"),
                 sample_period_duration=minutes(60),
                 history_duration=minutes(conf_in.nwp[nwp_key].history_minutes),
                 forecast_duration=minutes(conf_in.nwp[nwp_key].forecast_minutes),
-                # The NWP forecast will always be at least 180 minutes stale
-                dropout_timedeltas=[minutes(-180)],
-                dropout_frac=0 if production else 1.0,
+                dropout_timedeltas=dropout_timedeltas,
+                dropout_frac=0 if production else conf_in.nwp[nwp_key].dropout_fraction,
             )
 
     if "sat" in datapipes_dict:
@@ -774,11 +791,12 @@ def slice_datapipes_by_time(
         )
 
         # Dropout on the PV, but not the future PV
+
+        dropout_timedeltas = minutes_list_to_timedeltas(conf_in.pv.dropout_timedeltas_minutes)
+
         pv_dropout_time_datapipe = get_t0_datapipe("pv").draw_dropout_time(
-            # All PV data could be delayed by up to 30 minutes
-            # (this does not stem from production - just setting for now)
-            dropout_timedeltas=[minutes(m) for m in range(-30, 0, 5)],
-            dropout_frac=0 if production else 0.5,
+            dropout_timedeltas=dropout_timedeltas,
+            dropout_frac=0 if production else conf_in.pv.dropout_fraction,
         )
 
         datapipes_dict["pv"] = datapipes_dict["pv"].apply_dropout_time(
@@ -786,8 +804,7 @@ def slice_datapipes_by_time(
         )
 
         # Apply extra PV dropout using different delays per system and dropping out
-        # entire PV systems
-        # independently
+        # entire PV systems independently
         if not production:
             datapipes_dict["pv"].apply_pv_dropout(
                 system_dropout_fractions=np.linspace(0, 0.2, 100),
@@ -813,12 +830,14 @@ def slice_datapipes_by_time(
             fill_selection=production,
         )
 
+        dropout_timedeltas = minutes_list_to_timedeltas(conf_in.wind.dropout_timedeltas_minutes)
+
         # Dropout on the Wind, but not the future Wind
         wind_dropout_time_datapipe = get_t0_datapipe("wind").draw_dropout_time(
             # All Wind data could be delayed by up to 30 minutes
             # (this does not stem from production - just setting for now)
-            dropout_timedeltas=[minutes(m) for m in range(-30, 0, 5)],
-            dropout_frac=0 if production else 0.5,
+            dropout_timedeltas=dropout_timedeltas,
+            dropout_frac=0 if production else conf_in.wind.dropout_fraction,
         )
 
         datapipes_dict["wind"] = datapipes_dict["wind"].apply_dropout_time(
@@ -845,11 +864,13 @@ def slice_datapipes_by_time(
         )
 
         # Dropout on the sensor, but not the future sensor
+        dropout_timedeltas = minutes_list_to_timedeltas(conf_in.sensor.dropout_timedeltas_minutes)
+
         sensor_dropout_time_datapipe = get_t0_datapipe("sensor").draw_dropout_time(
             # All sensor data could be delayed by up to 30 minutes
             # (this does not stem from production - just setting for now)
-            dropout_timedeltas=[minutes(m) for m in range(-30, 0, 5)],
-            dropout_frac=0.1 if production else 1,
+            dropout_timedeltas=dropout_timedeltas,
+            dropout_frac=0 if production else conf_in.sensor.dropout_fraction,
         )
 
         datapipes_dict["sensor"] = datapipes_dict["sensor"].apply_dropout_time(
@@ -876,10 +897,11 @@ def slice_datapipes_by_time(
         )
 
         # Dropout on the GSP, but not the future GSP
+        dropout_timedeltas = minutes_list_to_timedeltas(conf_in.gsp.dropout_timedeltas_minutes)
+
         gsp_dropout_time_datapipe = get_t0_datapipe("gsp").draw_dropout_time(
-            # GSP data for time t0 may be missing. Only have value for t0-30mins
-            dropout_timedeltas=[minutes(-30)],
-            dropout_frac=0 if production else 0.1,
+            dropout_timedeltas=dropout_timedeltas,
+            dropout_frac=0 if production else conf_in.gsp.dropout_fraction,
         )
 
         datapipes_dict["gsp"] = datapipes_dict["gsp"].apply_dropout_time(
@@ -946,35 +968,35 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             datapipes_to_return[key] = datapipe.select_time_slice_nwp(
                 t0_datapipe=used_datapipes[key + "_t0"],
                 sample_period_duration=timedelta(hours=1),
-                history_duration=timedelta(
-                    minutes=configuration.input_data.nwp[nwp_source].history_minutes
+                history_duration=minutes(
+                    configuration.input_data.nwp[nwp_source].history_minutes
                 ),
-                forecast_duration=timedelta(
-                    minutes=configuration.input_data.nwp[nwp_source].forecast_minutes
+                forecast_duration=minutes(
+                    configuration.input_data.nwp[nwp_source].forecast_minutes
                 ),
             )
 
         if "sat" == key:
             datapipes_to_return[key] = datapipe.select_time_slice(
                 t0_datapipe=used_datapipes[key + "_t0"],
-                history_duration=timedelta(
-                    minutes=configuration.input_data.satellite.history_minutes
+                history_duration=minutes(
+                    configuration.input_data.satellite.history_minutes
                 ),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.satellite.time_resolution_minutes
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.satellite.time_resolution_minutes
                 ),
             )
 
         if "hrv" == key:
             datapipes_to_return[key] = datapipe.select_time_slice(
                 t0_datapipe=used_datapipes[key + "_t0"],
-                history_duration=timedelta(
-                    minutes=configuration.input_data.hrvsatellite.history_minutes
+                history_duration=minutes(
+                    configuration.input_data.hrvsatellite.history_minutes
                 ),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.hrvsatellite.time_resolution_minutes
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.hrvsatellite.time_resolution_minutes
                 ),
             )
 
@@ -983,18 +1005,18 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             pv_dp1, pv_dp2 = datapipe.fork(2)
             datapipes_to_return[key] = pv_dp1.select_time_slice(
                 t0_datapipe=pv_1,
-                history_duration=timedelta(minutes=configuration.input_data.pv.history_minutes),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.pv.time_resolution_minutes
+                history_duration=minutes(configuration.input_data.pv.history_minutes),
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.pv.time_resolution_minutes
                 ),
             )
             datapipes_to_return[key + "_future"] = pv_dp2.select_time_slice(
                 t0_datapipe=pv_2,
-                history_duration=timedelta(minutes=0),
-                forecast_duration=timedelta(minutes=configuration.input_data.pv.forecast_minutes),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.pv.time_resolution_minutes
+                history_duration=minutes(0),
+                forecast_duration=minutes(configuration.input_data.pv.forecast_minutes),
+                sample_period_duration=minutes(
+                    configuration.input_data.pv.time_resolution_minutes
                 ),
             )
 
@@ -1003,18 +1025,18 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             wind_dp1, wind_dp2 = datapipe.fork(2)
             datapipes_to_return[key] = wind_dp1.select_time_slice(
                 t0_datapipe=wind_1,
-                history_duration=timedelta(minutes=configuration.input_data.wind.history_minutes),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.wind.time_resolution_minutes
+                history_duration=minutes(configuration.input_data.wind.history_minutes),
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.wind.time_resolution_minutes
                 ),
             )
             datapipes_to_return[key + "_future"] = wind_dp2.select_time_slice(
                 t0_datapipe=wind_2,
-                history_duration=timedelta(minutes=0),
-                forecast_duration=timedelta(minutes=configuration.input_data.wind.forecast_minutes),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.wind.time_resolution_minutes
+                history_duration=minutes(0),
+                forecast_duration=minutes(configuration.input_data.wind.forecast_minutes),
+                sample_period_duration=minutes(
+                    configuration.input_data.wind.time_resolution_minutes
                 ),
             )
 
@@ -1023,20 +1045,20 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             sensor_dp1, sensor_dp2 = datapipe.fork(2)
             datapipes_to_return[key] = sensor_dp1.select_time_slice(
                 t0_datapipe=sensor_1,
-                history_duration=timedelta(minutes=configuration.input_data.sensor.history_minutes),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.sensor.time_resolution_minutes
+                history_duration=minutes(configuration.input_data.sensor.history_minutes),
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.sensor.time_resolution_minutes
                 ),
             )
             datapipes_to_return[key + "_future"] = sensor_dp2.select_time_slice(
                 t0_datapipe=sensor_2,
-                history_duration=timedelta(minutes=0),
-                forecast_duration=timedelta(
-                    minutes=configuration.input_data.sensor.forecast_minutes
+                history_duration=minutes(0),
+                forecast_duration=minutes(
+                    configuration.input_data.sensor.forecast_minutes
                 ),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.sensor.time_resolution_minutes
+                sample_period_duration=minutes(
+                    configuration.input_data.sensor.time_resolution_minutes
                 ),
             )
 
@@ -1045,18 +1067,18 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             gsp_dp1, gsp_dp2 = datapipe.fork(2)
             datapipes_to_return[key] = gsp_dp1.select_time_slice(
                 t0_datapipe=gsp_1,
-                history_duration=timedelta(minutes=configuration.input_data.gsp.history_minutes),
-                forecast_duration=timedelta(minutes=0),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.gsp.time_resolution_minutes
+                history_duration=minutes(configuration.input_data.gsp.history_minutes),
+                forecast_duration=minutes(0),
+                sample_period_duration=minutes(
+                    configuration.input_data.gsp.time_resolution_minutes
                 ),
             )
             datapipes_to_return[key + "_future"] = gsp_dp2.select_time_slice(
                 t0_datapipe=gsp_2,
-                history_duration=timedelta(minutes=0),
-                forecast_duration=timedelta(minutes=configuration.input_data.gsp.forecast_minutes),
-                sample_period_duration=timedelta(
-                    minutes=configuration.input_data.gsp.time_resolution_minutes
+                history_duration=minutes(0),
+                forecast_duration=minutes(configuration.input_data.gsp.forecast_minutes),
+                sample_period_duration=minutes(
+                    configuration.input_data.gsp.time_resolution_minutes
                 ),
             )
     if "topo" in used_datapipes.keys():
@@ -1070,8 +1092,6 @@ def create_t0_and_loc_datapipes(
     configuration: Configuration,
     key_for_t0: str = "gsp",
     shuffle: bool = True,
-    nwp_max_dropout_minutes: int = 0,
-    nwp_max_staleness_minutes: int = 180,
 ):
     """
     Takes source datapipes and returns datapipes of appropriate sample pairs of locations and times.
@@ -1085,12 +1105,6 @@ def create_t0_and_loc_datapipes(
         key_for_t0: Key to use for the t0 datapipe. Must be "gsp" or "pv".
         shuffle: Whether to use the internal shuffle function when yielding location times. Else
             location times will be heavily ordered.
-        nwp_max_dropout_minutes: If using dropout on NWP, sometimes we have to go back to previous
-            NWP init time. In order to accomodate for this possibility in selecting times, set
-            `nwp_max_dropout_minutes` as the max NWP dropout delay you plan to use.
-        nwp_max_staleness_minutes: Sets a limit on how stale an NWP init time is allowed to be
-            whilst still being used to costruct an example
-
     Returns:
         location datapipe, t0 datapipe
 
@@ -1102,8 +1116,7 @@ def create_t0_and_loc_datapipes(
         "wind",
         "sensor",
     ]
-    assert nwp_max_staleness_minutes >= nwp_max_dropout_minutes
-
+    
     contiguous_time_datapipes = []  # Used to store contiguous time periods from each data source
 
     datapipes_dict[key_for_t0], key_datapipe = datapipes_dict[key_for_t0].fork(2, buffer_size=5)
@@ -1122,11 +1135,22 @@ def create_t0_and_loc_datapipes(
                 # Different config setting per NWP source
                 nwp_conf = configuration.input_data.nwp[nwp_key]
 
-                # NWP is a forecast product so gets its own contiguous function
+                if nwp_conf.dropout_timedeltas_minutes is None:
+                    max_dropout = minutes(0)
+                else:
+                    max_dropout = minutes(np.max(np.abs(nwp_conf.dropout_timedeltas_minutes)))
+
+                if nwp_conf.max_staleness_minutes is None:
+                    max_staleness = None
+                else:
+                    max_staleness = minutes(nwp_conf.max_staleness_minutes)
+                
+                 # NWP is a forecast product so gets its own contiguous function
                 time_periods = datapipe_copy.find_contiguous_t0_time_periods_nwp(
-                    history_duration=timedelta(minutes=nwp_conf.history_minutes),
-                    max_staleness=timedelta(minutes=nwp_max_staleness_minutes),
-                    max_dropout=timedelta(minutes=nwp_max_dropout_minutes),
+                    history_duration=minutes(nwp_conf.history_minutes),
+                    forecast_duration=minutes(nwp_conf.forecast_duration),
+                    max_staleness=max_staleness,
+                    max_dropout=max_dropout,
                     time_dim="init_time_utc",
                 )
 
@@ -1175,9 +1199,9 @@ def create_t0_and_loc_datapipes(
             datapipes_dict[key], datapipe_copy = datapipes_dict[key].fork(2, buffer_size=5)
 
             time_periods = datapipe_copy.find_contiguous_t0_time_periods(
-                sample_period_duration=timedelta(minutes=sample_frequency),
-                history_duration=timedelta(minutes=history_duration),
-                forecast_duration=timedelta(minutes=forecast_duration),
+                sample_period_duration=minutes(sample_frequency),
+                history_duration=minutes(history_duration),
+                forecast_duration=minutes(forecast_duration),
                 time_dim=time_dim,
             )
 

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -1141,7 +1141,7 @@ def create_t0_and_loc_datapipes(
                 if nwp_conf.dropout_timedeltas_minutes is None:
                     max_dropout = minutes(0)
                 else:
-                    max_dropout = minutes(np.max(np.abs(nwp_conf.dropout_timedeltas_minutes)))
+                    max_dropout = minutes(int(np.max(np.abs(nwp_conf.dropout_timedeltas_minutes))))
 
                 if nwp_conf.max_staleness_minutes is None:
                     max_staleness = None

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -691,6 +691,13 @@ def slice_datapipes_by_time(
 
     # Satelite and HRV satellite should drop out simultaneously when they dropout
     if "sat" in datapipes_dict or "hrv" in datapipes_dict:
+        
+        if "sat" in datapipes_dict and "hrv" in datapipes_dict:
+            logger.warn(
+                "Both sat and hrv in data sources. But dropout values will only be taken from sat "
+                "and apllied to both"
+            )
+        
         if "sat" in datapipes_dict:
             conf_sathrv = conf_in.satellite
         else:
@@ -809,9 +816,14 @@ def slice_datapipes_by_time(
         # Apply extra PV dropout using different delays per system and dropping out
         # entire PV systems independently
         if not production:
+            system_dropout_timedeltas = minutes_list_to_timedeltas(
+                conf_in.pv.system_dropout_timedeltas_minutes
+            )
+                        
             datapipes_dict["pv"].apply_pv_dropout(
-                system_dropout_fractions=np.linspace(0, 0.2, 100),
-                system_dropout_timedeltas=[minutes(m) for m in [-15, -10, -5, 0]],
+                min_frac=conf_in.pv.system_dropout_fraction_min,
+                max_frac=conf_in.pv.system_dropout_fraction_max,
+                system_dropout_timedeltas=system_dropout_timedeltas,
             )
 
     if "wind" in datapipes_dict:

--- a/ocf_datapipes/training/common.py
+++ b/ocf_datapipes/training/common.py
@@ -111,9 +111,7 @@ def open_and_return_datapipes(
         gsp_datapipe = OpenGSP(
             gsp_pv_power_zarr_path=configuration.input_data.gsp.gsp_zarr_path
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=minutes(
-                configuration.input_data.gsp.time_resolution_minutes
-            ),
+            sample_period_duration=minutes(configuration.input_data.gsp.time_resolution_minutes),
             history_duration=minutes(configuration.input_data.gsp.history_minutes),
         )
 
@@ -145,9 +143,7 @@ def open_and_return_datapipes(
                 sample_period_duration=minutes(
                     configuration.input_data.satellite.time_resolution_minutes
                 ),
-                history_duration=minutes(
-                    configuration.input_data.satellite.history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.satellite.history_minutes),
             )
         )
 
@@ -161,9 +157,7 @@ def open_and_return_datapipes(
             sample_period_duration=minutes(
                 configuration.input_data.hrvsatellite.time_resolution_minutes
             ),
-            history_duration=minutes(
-                configuration.input_data.hrvsatellite.history_minutes
-            ),
+            history_duration=minutes(configuration.input_data.hrvsatellite.history_minutes),
         )
 
         used_datapipes["hrv"] = sat_hrv_datapipe
@@ -173,9 +167,7 @@ def open_and_return_datapipes(
         pv_datapipe = OpenPVFromNetCDF(
             pv=configuration.input_data.pv
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=minutes(
-                configuration.input_data.pv.time_resolution_minutes
-            ),
+            sample_period_duration=minutes(configuration.input_data.pv.time_resolution_minutes),
             history_duration=minutes(configuration.input_data.pv.history_minutes),
         )
 
@@ -186,9 +178,7 @@ def open_and_return_datapipes(
         wind_datapipe = OpenWindFromNetCDF(
             wind=configuration.input_data.wind
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=minutes(
-                configuration.input_data.wind.time_resolution_minutes
-            ),
+            sample_period_duration=minutes(configuration.input_data.wind.time_resolution_minutes),
             history_duration=minutes(configuration.input_data.wind.history_minutes),
         )
 
@@ -199,9 +189,7 @@ def open_and_return_datapipes(
         sensor_datapipe = OpenAWOSFromNetCDF(
             configuration.input_data.sensor
         ).add_t0_idx_and_sample_period_duration(
-            sample_period_duration=minutes(
-                configuration.input_data.sensor.time_resolution_minutes
-            ),
+            sample_period_duration=minutes(configuration.input_data.sensor.time_resolution_minutes),
             history_duration=minutes(configuration.input_data.sensor.history_minutes),
         )
 
@@ -246,9 +234,7 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
             nwp_source = key.removeprefix("nwp/")
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
                 sample_period_duration=timedelta(hours=3),  # Init times are 3 hours apart
-                history_duration=minutes(
-                    configuration.input_data.nwp[nwp_source].history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.nwp[nwp_source].history_minutes),
                 forecast_duration=minutes(
                     configuration.input_data.nwp[nwp_source].forecast_minutes
                 ),
@@ -261,9 +247,7 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
                 sample_period_duration=minutes(
                     configuration.input_data.satellite.time_resolution_minutes
                 ),
-                history_duration=minutes(
-                    configuration.input_data.satellite.history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.satellite.history_minutes),
                 forecast_duration=minutes(0),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
@@ -273,18 +257,14 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
                 sample_period_duration=minutes(
                     configuration.input_data.hrvsatellite.time_resolution_minutes
                 ),
-                history_duration=minutes(
-                    configuration.input_data.hrvsatellite.history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.hrvsatellite.history_minutes),
                 forecast_duration=minutes(0),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
 
         if "pv" == key:
             time_periods_datapipe = forked_datapipes[1].find_contiguous_t0_time_periods(
-                sample_period_duration=minutes(
-                    configuration.input_data.pv.time_resolution_minutes
-                ),
+                sample_period_duration=minutes(configuration.input_data.pv.time_resolution_minutes),
                 history_duration=minutes(configuration.input_data.pv.history_minutes),
                 forecast_duration=minutes(configuration.input_data.pv.forecast_minutes),
             )
@@ -314,9 +294,7 @@ def get_and_return_overlapping_time_periods_and_t0(used_datapipes: dict, key_for
                     configuration.input_data.sensor.time_resolution_minutes
                 ),
                 history_duration=minutes(configuration.input_data.sensor.history_minutes),
-                forecast_duration=minutes(
-                    configuration.input_data.sensor.forecast_minutes
-                ),
+                forecast_duration=minutes(configuration.input_data.sensor.forecast_minutes),
             )
             datapipes_for_time_periods.append(time_periods_datapipe)
 
@@ -636,7 +614,7 @@ def minutes_list_to_timedeltas(list_ints):
     if list_ints is None:
         return list_ints
     else:
-        return [minutes(m) for m in list_ints] 
+        return [minutes(m) for m in list_ints]
 
 
 def slice_datapipes_by_time(
@@ -647,7 +625,7 @@ def slice_datapipes_by_time(
 ) -> None:
     """
     Modifies a dictionary of datapipes in-place to yield samples for given times t0.
-    
+
     Note that where dropout is mentioned here, this is only applied if production=False.
 
     The NWP data* will may include dropout to a earlier init time depending on the config.
@@ -661,8 +639,8 @@ def slice_datapipes_by_time(
     The GSP data is split into "gsp" and "gsp_future" keys. Depending on the config, the most recent
     data may be dropped out and replaced with NaNs
 
-    The PV data* is also split it "pv" and "pv_future" keys. Depending on the config, the most 
-    recent data may be dropped out and replaced with NaNs. Additionally, the PV systems may be 
+    The PV data* is also split it "pv" and "pv_future" keys. Depending on the config, the most
+    recent data may be dropped out and replaced with NaNs. Additionally, the PV systems may be
     independenly dropped out rather than a constant dropout time being used across all systems.
 
     * if included
@@ -691,13 +669,12 @@ def slice_datapipes_by_time(
 
     # Satelite and HRV satellite should drop out simultaneously when they dropout
     if "sat" in datapipes_dict or "hrv" in datapipes_dict:
-        
         if "sat" in datapipes_dict and "hrv" in datapipes_dict:
             logger.warn(
                 "Both sat and hrv in data sources. But dropout values will only be taken from sat "
                 "and apllied to both"
             )
-        
+
         if "sat" in datapipes_dict:
             conf_sathrv = conf_in.satellite
         else:
@@ -717,7 +694,6 @@ def slice_datapipes_by_time(
     if "nwp" in datapipes_dict:
         # NWP is nested in the dict
         for nwp_key, dp in datapipes_dict["nwp"].items():
-
             dropout_timedeltas = minutes_list_to_timedeltas(
                 conf_in.nwp[nwp_key].dropout_timedeltas_minutes
             )
@@ -819,7 +795,7 @@ def slice_datapipes_by_time(
             system_dropout_timedeltas = minutes_list_to_timedeltas(
                 conf_in.pv.system_dropout_timedeltas_minutes
             )
-                        
+
             datapipes_dict["pv"].apply_pv_dropout(
                 min_frac=conf_in.pv.system_dropout_fraction_min,
                 max_frac=conf_in.pv.system_dropout_fraction_max,
@@ -983,9 +959,7 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             datapipes_to_return[key] = datapipe.select_time_slice_nwp(
                 t0_datapipe=used_datapipes[key + "_t0"],
                 sample_period_duration=timedelta(hours=1),
-                history_duration=minutes(
-                    configuration.input_data.nwp[nwp_source].history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.nwp[nwp_source].history_minutes),
                 forecast_duration=minutes(
                     configuration.input_data.nwp[nwp_source].forecast_minutes
                 ),
@@ -994,9 +968,7 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
         if "sat" == key:
             datapipes_to_return[key] = datapipe.select_time_slice(
                 t0_datapipe=used_datapipes[key + "_t0"],
-                history_duration=minutes(
-                    configuration.input_data.satellite.history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.satellite.history_minutes),
                 forecast_duration=minutes(0),
                 sample_period_duration=minutes(
                     configuration.input_data.satellite.time_resolution_minutes
@@ -1006,9 +978,7 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
         if "hrv" == key:
             datapipes_to_return[key] = datapipe.select_time_slice(
                 t0_datapipe=used_datapipes[key + "_t0"],
-                history_duration=minutes(
-                    configuration.input_data.hrvsatellite.history_minutes
-                ),
+                history_duration=minutes(configuration.input_data.hrvsatellite.history_minutes),
                 forecast_duration=minutes(0),
                 sample_period_duration=minutes(
                     configuration.input_data.hrvsatellite.time_resolution_minutes
@@ -1022,17 +992,13 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
                 t0_datapipe=pv_1,
                 history_duration=minutes(configuration.input_data.pv.history_minutes),
                 forecast_duration=minutes(0),
-                sample_period_duration=minutes(
-                    configuration.input_data.pv.time_resolution_minutes
-                ),
+                sample_period_duration=minutes(configuration.input_data.pv.time_resolution_minutes),
             )
             datapipes_to_return[key + "_future"] = pv_dp2.select_time_slice(
                 t0_datapipe=pv_2,
                 history_duration=minutes(0),
                 forecast_duration=minutes(configuration.input_data.pv.forecast_minutes),
-                sample_period_duration=minutes(
-                    configuration.input_data.pv.time_resolution_minutes
-                ),
+                sample_period_duration=minutes(configuration.input_data.pv.time_resolution_minutes),
             )
 
         if "wind" == key:
@@ -1069,9 +1035,7 @@ def add_selected_time_slices_from_datapipes(used_datapipes: dict):
             datapipes_to_return[key + "_future"] = sensor_dp2.select_time_slice(
                 t0_datapipe=sensor_2,
                 history_duration=minutes(0),
-                forecast_duration=minutes(
-                    configuration.input_data.sensor.forecast_minutes
-                ),
+                forecast_duration=minutes(configuration.input_data.sensor.forecast_minutes),
                 sample_period_duration=minutes(
                     configuration.input_data.sensor.time_resolution_minutes
                 ),
@@ -1120,6 +1084,7 @@ def create_t0_and_loc_datapipes(
         key_for_t0: Key to use for the t0 datapipe. Must be "gsp" or "pv".
         shuffle: Whether to use the internal shuffle function when yielding location times. Else
             location times will be heavily ordered.
+
     Returns:
         location datapipe, t0 datapipe
 
@@ -1131,7 +1096,7 @@ def create_t0_and_loc_datapipes(
         "wind",
         "sensor",
     ]
-    
+
     contiguous_time_datapipes = []  # Used to store contiguous time periods from each data source
 
     datapipes_dict[key_for_t0], key_datapipe = datapipes_dict[key_for_t0].fork(2, buffer_size=5)
@@ -1159,8 +1124,8 @@ def create_t0_and_loc_datapipes(
                     max_staleness = None
                 else:
                     max_staleness = minutes(nwp_conf.max_staleness_minutes)
-                
-                 # NWP is a forecast product so gets its own contiguous function
+
+                # NWP is a forecast product so gets its own contiguous function
                 time_periods = datapipe_copy.find_contiguous_t0_time_periods_nwp(
                     history_duration=minutes(nwp_conf.history_minutes),
                     forecast_duration=minutes(nwp_conf.forecast_minutes),

--- a/tests/data/configs/test.yaml
+++ b/tests/data/configs/test.yaml
@@ -6,7 +6,7 @@ input_data:
   gsp:
     gsp_zarr_path: tests/data/gsp/test.zarr
     history_minutes: 120
-    dropout_timedeltas_minutes: [-30,]
+    dropout_timedeltas_minutes: [-30]
     dropout_fraction: 0.1
   nwp:
     ukv:

--- a/tests/data/configs/test.yaml
+++ b/tests/data/configs/test.yaml
@@ -45,6 +45,9 @@ input_data:
     pv_image_size_meters_width: 10000000
     n_pv_systems_per_example: 32
     pv_ml_ids: []
+    system_dropout_timedeltas_minutes: [-15, -10, -5, 0]
+    system_dropout_fraction_min: 0
+    system_dropout_fraction_max: 0.2
   satellite:
     satellite_channels:
       - IR_016

--- a/tests/data/configs/test.yaml
+++ b/tests/data/configs/test.yaml
@@ -6,6 +6,8 @@ input_data:
   gsp:
     gsp_zarr_path: tests/data/gsp/test.zarr
     history_minutes: 120
+    dropout_timedeltas_minutes: [-30,]
+    dropout_fraction: 0.1
   nwp:
     ukv:
       nwp_channels:
@@ -18,6 +20,8 @@ input_data:
       forecast_minutes: 120
       time_resolution_minutes: 60
       index_by_id: True
+      dropout_timedeltas_minutes: [-180]
+      dropout_fraction: 1.0
   wind:
     wind_files_groups:
       - label: india
@@ -55,6 +59,8 @@ input_data:
     hrvsatellite_zarr_path: tests/data/hrv_sat_data.zarr
     history_minutes: 30
     forecast_minutes: 60
+    dropout_timedeltas_minutes: [-60, -30]
+    dropout_fraction: 1.0
   sun:
     sun_zarr_path: tests/data/sun/test.zarr
   topographic:

--- a/tests/select/test_apply_pv_dropout.py
+++ b/tests/select/test_apply_pv_dropout.py
@@ -29,7 +29,7 @@ def test_apply_pv_dropout(passiv_datapipe):
     # No dropout should have been applied
     for pv_data in pv_dropout_datapipe:
         assert not np.isnan(pv_data.values).any()
-        
+
     # ----------------
     # Also apply no dropout
     pv_dropout_datapipe = ApplyPVDropout(

--- a/tests/select/test_apply_pv_dropout.py
+++ b/tests/select/test_apply_pv_dropout.py
@@ -21,7 +21,21 @@ def test_apply_pv_dropout(passiv_datapipe):
     # Apply no dropout
     pv_dropout_datapipe = ApplyPVDropout(
         pv_datapipe,
-        system_dropout_fractions=[0],
+        min_frac=0,
+        max_frac=0,
+        system_dropout_timedeltas=None,
+    )
+
+    # No dropout should have been applied
+    for pv_data in pv_dropout_datapipe:
+        assert not np.isnan(pv_data.values).any()
+        
+    # ----------------
+    # Also apply no dropout
+    pv_dropout_datapipe = ApplyPVDropout(
+        pv_datapipe,
+        min_frac=0,
+        max_frac=0,
         system_dropout_timedeltas=[timedelta(minutes=0)],
     )
 
@@ -33,7 +47,8 @@ def test_apply_pv_dropout(passiv_datapipe):
     # Apply only system dropout
     pv_dropout_datapipe = ApplyPVDropout(
         pv_datapipe,
-        system_dropout_fractions=[0.5],
+        min_frac=0.4,
+        max_frac=0.6,
         system_dropout_timedeltas=[timedelta(minutes=0)],
     )
 
@@ -47,7 +62,8 @@ def test_apply_pv_dropout(passiv_datapipe):
     # Apply only delay dropout
     pv_dropout_datapipe = ApplyPVDropout(
         pv_datapipe,
-        system_dropout_fractions=[0.0],
+        min_frac=0,
+        max_frac=0,
         system_dropout_timedeltas=[timedelta(minutes=-5)],
     )
 
@@ -59,7 +75,8 @@ def test_apply_pv_dropout(passiv_datapipe):
     # Apply combo dropout
     pv_dropout_datapipe = ApplyPVDropout(
         pv_datapipe,
-        system_dropout_fractions=[0.5],
+        min_frac=0.4,
+        max_frac=0.6,
         system_dropout_timedeltas=[timedelta(minutes=-5)],
     )
 

--- a/tests/select/test_filter_to_contiguous_time_periods.py
+++ b/tests/select/test_filter_to_contiguous_time_periods.py
@@ -160,7 +160,7 @@ def test_find_contiguous_t0_time_periods_nwp():
 
         # Create initial datapipe
         xr_data = pd.DataFrame(datetimes, columns=["init_time_utc"]).to_xarray()
-        xr_data = xr_data.assign_coords({"step":steps})
+        xr_data = xr_data.assign_coords({"step": steps})
         time_datapipe = IterableWrapper([xr_data])
 
         time_periods = time_datapipe.find_contiguous_t0_time_periods_nwp(

--- a/tests/select/test_filter_to_contiguous_time_periods.py
+++ b/tests/select/test_filter_to_contiguous_time_periods.py
@@ -147,6 +147,7 @@ def test_find_contiguous_t0_time_periods_nwp():
         pd.date_range("2023-01-01 03:00", "2023-01-02 21:00", freq=freq),
         [1, 4, 5, 6, 7, 9, 10],
     )
+    steps = [timedelta(hours=i) for i in range(24)]
 
     # Choose some history durations and max stalenesses
     history_durations_hr = [0, 2, 2, 2]
@@ -154,15 +155,17 @@ def test_find_contiguous_t0_time_periods_nwp():
 
     for i in range(len(expected_results)):
         history_duration = timedelta(hours=history_durations_hr[i])
+        forecast_duration = timedelta(hours=3)
         max_staleness = timedelta(hours=max_stalenesses_hr[i])
 
         # Create initial datapipe
-        time_datapipe = IterableWrapper(
-            [pd.DataFrame(datetimes, columns=["init_time_utc"]).to_xarray()]
-        )
+        xr_data = pd.DataFrame(datetimes, columns=["init_time_utc"]).to_xarray()
+        xr_data = xr_data.assign_coords({"step":steps})
+        time_datapipe = IterableWrapper([xr_data])
 
         time_periods = time_datapipe.find_contiguous_t0_time_periods_nwp(
             history_duration=history_duration,
+            forecast_duration=forecast_duration,
             max_staleness=max_staleness,
             time_dim="init_time_utc",
         )


### PR DESCRIPTION
# Pull Request

## Description

Previously the dropout and max staleness values used in the pvnet and windnet datapipes were hard-coded into their common functions. This moves these values to the config file.

Also a little tidying

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
