### PR TITLE
Fix lon-lat switch bug

### DIFF
--- a/ocf_datapipes/transform/numpy_batch/sun_position.py
+++ b/ocf_datapipes/transform/numpy_batch/sun_position.py
@@ -16,8 +16,8 @@ from ocf_datapipes.utils.consts import (
 from ocf_datapipes.utils.geospatial import osgb_to_lon_lat
 
 
-def _get_azimuth_and_elevation(lat, lon, dt, must_be_finite):
-    if not np.isfinite([lat, lon]).all():
+def _get_azimuth_and_elevation(lon, lat, dt, must_be_finite):
+    if not np.isfinite([lon, lat]).all():
         if must_be_finite:
             raise ValueError(f"Non-finite (lon, lat) = ({lon}, {lat}")
         return (


### PR DESCRIPTION
# Pull Request

## Description

Somewhere in the switch to standardise and always have spatial coordinates like (x, y) I made a mistake on this one. 

This fixes the bug giving the wrong elevation and azimuth.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
