### PR TITLE
Add NumpyBatch utils from PVNet

### DIFF
--- a/ocf_datapipes/batch/__init__.py
+++ b/ocf_datapipes/batch/__init__.py
@@ -12,3 +12,4 @@ from .merge_numpy_examples_to_batch import (
 )
 from .merge_numpy_modalities import MergeNumpyModalitiesIterDataPipe as MergeNumpyModalities
 from .merge_numpy_modalities import MergeNWPNumpyModalitiesIterDataPipe as MergeNWPNumpyModalities
+from .utils import batch_to_tensor, copy_batch_to_device

--- a/ocf_datapipes/batch/__init__.py
+++ b/ocf_datapipes/batch/__init__.py
@@ -1,5 +1,5 @@
 """Datapipes for batching together data"""
-from .batches import BatchKey, NumpyBatch, NWPBatchKey, NWPNumpyBatch, XarrayBatch
+from .batches import BatchKey, NumpyBatch, NWPBatchKey, NWPNumpyBatch, TensorBatch, XarrayBatch
 from .merge_numpy_examples_to_batch import (
     MergeNumpyBatchIterDataPipe as MergeNumpyBatch,
 )

--- a/ocf_datapipes/batch/batches.py
+++ b/ocf_datapipes/batch/batches.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 from typing import Union
 
 import numpy as np
+import torch
 import xarray as xr
 
 
@@ -229,3 +230,5 @@ NWPNumpyBatch = dict[NWPBatchKey, np.ndarray]
 NumpyBatch = dict[BatchKey, Union[np.ndarray, dict[str, NWPNumpyBatch]]]
 
 XarrayBatch = dict[BatchKey, Union[xr.DataArray, xr.Dataset]]
+
+TensorBatch = dict[BatchKey, Union[torch.Tensor, dict[str, dict[NWPBatchKey, torch.Tensor]]]]

--- a/ocf_datapipes/batch/utils.py
+++ b/ocf_datapipes/batch/utils.py
@@ -3,8 +3,17 @@ import numpy as np
 import torch
 
 
-def copy_batch_to_device(batch, device):
-    """Moves a dict-batch of tensors to new device."""
+def copy_batch_to_device(batch: dict, device: torch.device) -> dict:
+    """
+    Moves a dict-batch of tensors to new device.
+
+    Args:
+        batch: dict with tensors to move
+        device: Device to move tensors to
+
+    Returns:
+        A dict with tensors moved to new device
+    """
     batch_copy = {}
 
     for k, v in batch.items():
@@ -18,8 +27,16 @@ def copy_batch_to_device(batch, device):
     return batch_copy
 
 
-def batch_to_tensor(batch):
-    """Moves numpy batch to a tensor"""
+def batch_to_tensor(batch: dict) -> dict:
+    """
+    Moves numpy batch to a tensor
+
+    Args:
+        batch: dict-like batch with data in numpy arrays
+
+    Returns:
+        A batch with data in torch tensors
+    """
     for k, v in batch.items():
         if isinstance(v, dict):
             # Recursion to reach the nested NWP

--- a/ocf_datapipes/batch/utils.py
+++ b/ocf_datapipes/batch/utils.py
@@ -2,13 +2,15 @@
 import numpy as np
 import torch
 
+from ocf_datapipes.batch import NumpyBatch, TensorBatch
 
-def copy_batch_to_device(batch: dict, device: torch.device) -> dict:
+
+def _copy_batch_to_device(batch: dict, device: torch.device) -> dict:
     """
-    Moves a dict-batch of tensors to new device.
+    Moves tensor leaves in a nested dict to a new device
 
     Args:
-        batch: dict with tensors to move
+        batch: nested dict with tensors to move
         device: Device to move tensors to
 
     Returns:
@@ -19,7 +21,7 @@ def copy_batch_to_device(batch: dict, device: torch.device) -> dict:
     for k, v in batch.items():
         if isinstance(v, dict):
             # Recursion to reach the nested NWP
-            batch_copy[k] = copy_batch_to_device(v, device)
+            batch_copy[k] = _copy_batch_to_device(v, device)
         elif isinstance(v, torch.Tensor):
             batch_copy[k] = v.to(device)
         else:
@@ -27,20 +29,47 @@ def copy_batch_to_device(batch: dict, device: torch.device) -> dict:
     return batch_copy
 
 
-def batch_to_tensor(batch: dict) -> dict:
+def copy_batch_to_device(batch: TensorBatch, device: torch.device) -> TensorBatch:
     """
-    Moves numpy batch to a tensor
+    Moves the tensors in a TensorBatch to a new device.
 
     Args:
-        batch: dict-like batch with data in numpy arrays
+        batch: TensorBatch with tensors to move
+        device: Device to move tensors to
 
     Returns:
-        A batch with data in torch tensors
+        TensorBatch with tensors moved to new device
+    """
+    return _copy_batch_to_device(batch, device)
+
+
+def _batch_to_tensor(batch: dict) -> dict:
+    """
+    Moves ndarrays in a nested dict to torch tensors
+
+    Args:
+        batch: nested dict with data in numpy arrays
+
+    Returns:
+        Nested dict with data in torch tensors
     """
     for k, v in batch.items():
         if isinstance(v, dict):
             # Recursion to reach the nested NWP
-            batch[k] = batch_to_tensor(v)
+            batch[k] = _batch_to_tensor(v)
         elif isinstance(v, np.ndarray) and np.issubdtype(v.dtype, np.number):
             batch[k] = torch.as_tensor(v)
     return batch
+
+
+def batch_to_tensor(batch: NumpyBatch) -> TensorBatch:
+    """
+    Moves data in a NumpyBatch to a TensorBatch
+
+    Args:
+        batch: NumpyBatch with data in numpy arrays
+
+    Returns:
+        TensorBatch with data in torch tensors
+    """
+    return _batch_to_tensor(batch)

--- a/ocf_datapipes/batch/utils.py
+++ b/ocf_datapipes/batch/utils.py
@@ -1,0 +1,29 @@
+"""Additional utils for working with batches"""
+import numpy as np
+import torch
+
+
+def copy_batch_to_device(batch, device):
+    """Moves a dict-batch of tensors to new device."""
+    batch_copy = {}
+
+    for k, v in batch.items():
+        if isinstance(v, dict):
+            # Recursion to reach the nested NWP
+            batch_copy[k] = copy_batch_to_device(v, device)
+        elif isinstance(v, torch.Tensor):
+            batch_copy[k] = v.to(device)
+        else:
+            batch_copy[k] = v
+    return batch_copy
+
+
+def batch_to_tensor(batch):
+    """Moves numpy batch to a tensor"""
+    for k, v in batch.items():
+        if isinstance(v, dict):
+            # Recursion to reach the nested NWP
+            batch[k] = batch_to_tensor(v)
+        elif isinstance(v, np.ndarray) and np.issubdtype(v.dtype, np.number):
+            batch[k] = torch.as_tensor(v)
+    return batch

--- a/ocf_datapipes/training/pvnet_site.py
+++ b/ocf_datapipes/training/pvnet_site.py
@@ -6,9 +6,8 @@ from typing import List, Optional
 import xarray as xr
 from torch.utils.data import IterDataPipe, functional_datapipe
 from torch.utils.data.datapipes.iter import IterableWrapper
-from ocf_datapipes.batch import BatchKey, NumpyBatch
 
-from ocf_datapipes.batch import MergeNumpyModalities, MergeNWPNumpyModalities
+from ocf_datapipes.batch import BatchKey, MergeNumpyModalities, MergeNWPNumpyModalities
 from ocf_datapipes.training.common import (
     DatapipeKeyForker,
     _get_datapipes_dict,

--- a/ocf_datapipes/training/windnet.py
+++ b/ocf_datapipes/training/windnet.py
@@ -123,7 +123,6 @@ class LoadDictDatasetIterDataPipe(IterDataPipe):
 
     def __iter__(self):
         """Iterate through each filename, loading it, uncombining it, and then yielding it"""
-        import numpy as np
 
         while True:
             for filename in self.filenames:

--- a/tests/batch/test_utils.py
+++ b/tests/batch/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from ocf_datapipes.batch import BatchKey, NumpyBatch
+from ocf_datapipes.batch import BatchKey, NumpyBatch, TensorBatch
 from ocf_datapipes.batch import copy_batch_to_device, batch_to_tensor
 
 
@@ -11,15 +11,20 @@ def _create_test_batch() -> NumpyBatch:
     return sample
 
 
-def test_batch_to_tensor():
-    batch = _create_test_batch()
+def test_batch_to_tensor() -> None:
+    batch: NumpyBatch = _create_test_batch()
     tensor_batch = batch_to_tensor(batch)
     assert isinstance(tensor_batch[BatchKey.satellite_actual], torch.Tensor)
 
 
-def test_copy_batch_to_device():
+def test_copy_batch_to_device() -> None:
     batch = _create_test_batch()
     tensor_batch = batch_to_tensor(batch)
     device = torch.device("cpu")
-    batch_copy = copy_batch_to_device(tensor_batch, device)
-    assert batch_copy[BatchKey.satellite_actual].device == device
+    batch_copy: TensorBatch = copy_batch_to_device(tensor_batch, device)
+    assert batch_copy[BatchKey.satellite_actual].device == device  # type: ignore
+
+
+if __name__ == "__main__":
+    test_batch_to_tensor()
+    test_copy_batch_to_device()

--- a/tests/batch/test_utils.py
+++ b/tests/batch/test_utils.py
@@ -1,0 +1,25 @@
+import numpy as np
+import torch
+
+from ocf_datapipes.batch import BatchKey, NumpyBatch
+from ocf_datapipes.batch import copy_batch_to_device, batch_to_tensor
+
+
+def _create_test_batch() -> NumpyBatch:
+    sample: NumpyBatch = {}
+    sample[BatchKey.satellite_actual] = np.full((12, 10, 24, 24), 0)
+    return sample
+
+
+def test_batch_to_tensor():
+    batch = _create_test_batch()
+    tensor_batch = batch_to_tensor(batch)
+    assert isinstance(tensor_batch[BatchKey.satellite_actual], torch.Tensor)
+
+
+def test_copy_batch_to_device():
+    batch = _create_test_batch()
+    tensor_batch = batch_to_tensor(batch)
+    device = torch.device("cpu")
+    batch_copy = copy_batch_to_device(tensor_batch, device)
+    assert batch_copy[BatchKey.satellite_actual].device == device


### PR DESCRIPTION
# Pull Request

## Description

Transfer functions from PVNet specific to NumpyBatches here. Type hints are very minimal because recursive type support is still quite tricky. I have tried to use a nested dict type `NestedDict = dict[Any, Union[T, "NestedDict[T]"]]` but have trouble getting mypy to recognize NumpyBatches as such. I would be very interested if someone can teach me how to do this properly.

Fixes https://github.com/openclimatefix/PVNet/issues/111

## How Has This Been Tested?

Logic comes for another repository. I have added a simple test in `tests/batch/test_utils.py`

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings