### PR TITLE
Unpin nowcasting_datamodel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pandas
 rioxarray
 pathy
 pyaml_env
-nowcasting_datamodel==1.5.30
+nowcasting_datamodel>=1.5.30
 gitpython
 geopandas
 dask


### PR DESCRIPTION
Having this pinned in datapipes and pinned in pvnet_app is causing harding to solve dependencies. Better to have this open here and only pinned in `pvnet_app` or similar apps

E.g. https://github.com/openclimatefix/pvnet_app/actions/runs/8708432423/job/23885773953?pr=68