### PR TITLE
Buffer fix

### DIFF
--- a/ocf_datapipes/select/filter_to_overlapping_time_periods.py
+++ b/ocf_datapipes/select/filter_to_overlapping_time_periods.py
@@ -136,11 +136,11 @@ def intersection_of_2_dataframes_of_periods(a: pd.DataFrame, b: pd.DataFrame) ->
         # to start no earlier than `a_start_dt`, and end no later than `a_end_dt`.
 
         # First, make a copy, so we don't clip the underlying data in `b`.
-        intersecting_periods = overlapping_periods.copy()
-        intersecting_periods.start_dt.clip(lower=a_period.start_dt, inplace=True)
-        intersecting_periods.end_dt.clip(upper=a_period.end_dt, inplace=True)
+        intersection = overlapping_periods.copy()
+        intersection["start_dt"] = intersection.start_dt.clip(lower=a_period.start_dt)
+        intersection["end_dt"] = intersection.end_dt.clip(upper=a_period.end_dt)
 
-        all_intersecting_periods.append(intersecting_periods)
+        all_intersecting_periods.append(intersection)
 
     all_intersecting_periods = pd.concat(all_intersecting_periods)
     return all_intersecting_periods.sort_values(by="start_dt").reset_index(drop=True)

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -187,7 +187,6 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         return xr_data.sel(time_utc=slice(start_dt, end_dt))
 
     def __iter__(self) -> Union[xr.DataArray, xr.Dataset]:
-
         for t0, xr_data in self.t0_datapipe.zip(self.source_datapipe):
             t0_datetime_utc = pd.Timestamp(t0)
             start_dt = t0_datetime_utc + self.interval_start

--- a/ocf_datapipes/select/select_time_slice.py
+++ b/ocf_datapipes/select/select_time_slice.py
@@ -187,9 +187,8 @@ class SelectTimeSliceIterDataPipe(IterDataPipe):
         return xr_data.sel(time_utc=slice(start_dt, end_dt))
 
     def __iter__(self) -> Union[xr.DataArray, xr.Dataset]:
-        xr_data = next(iter(self.source_datapipe))
 
-        for t0 in self.t0_datapipe:
+        for t0, xr_data in self.t0_datapipe.zip(self.source_datapipe):
             t0_datetime_utc = pd.Timestamp(t0)
             start_dt = t0_datetime_utc + self.interval_start
             end_dt = t0_datetime_utc + self.interval_end

--- a/ocf_datapipes/select/select_time_slice_nwp.py
+++ b/ocf_datapipes/select/select_time_slice_nwp.py
@@ -66,9 +66,10 @@ class SelectTimeSliceNWPIterDataPipe(IterDataPipe):
         """Iterate through both datapipes and convert Xarray dataset"""
 
         for t0, xr_data in self.t0_datapipe.zip(self.source_datapipe):
-            
             # The accumatation and non-accumulation channels
-            accum_channels = np.intersect1d(xr_data[self.channel_dim_name].values, self.accum_channels)
+            accum_channels = np.intersect1d(
+                xr_data[self.channel_dim_name].values, self.accum_channels
+            )
             non_accum_channels = np.setdiff1d(
                 xr_data[self.channel_dim_name].values, self.accum_channels
             )

--- a/tests/select/test_select_time_slice_nwp.py
+++ b/tests/select/test_select_time_slice_nwp.py
@@ -52,13 +52,15 @@ def test_select_time_slice_nwp(nwp_datapipe):
 
 def test_select_time_slice_nwp_diff(nwp_datapipe):
     ds_nwp = next(iter(nwp_datapipe))
+    
+    nwp_datapipe1, nwp_datapipe2 = nwp_datapipe.fork(2, buffer_size=3)
 
     t0 = pd.Timestamp(ds_nwp.init_time_utc.values[3])
     times = [t0 + timedelta(minutes=m) for m in [0, 30, 120]]
 
     # No diffing
     dropout_datapipe = SelectTimeSliceNWP(
-        nwp_datapipe,
+        nwp_datapipe1,
         IterableWrapper(times),
         sample_period_duration=timedelta(minutes=60),
         history_duration=timedelta(minutes=60),
@@ -69,7 +71,7 @@ def test_select_time_slice_nwp_diff(nwp_datapipe):
 
     # With diffing
     dropout_datapipe_diffed = SelectTimeSliceNWP(
-        nwp_datapipe,
+        nwp_datapipe2,
         IterableWrapper(times),
         sample_period_duration=timedelta(minutes=60),
         history_duration=timedelta(minutes=60),

--- a/tests/select/test_select_time_slice_nwp.py
+++ b/tests/select/test_select_time_slice_nwp.py
@@ -52,7 +52,7 @@ def test_select_time_slice_nwp(nwp_datapipe):
 
 def test_select_time_slice_nwp_diff(nwp_datapipe):
     ds_nwp = next(iter(nwp_datapipe))
-    
+
     nwp_datapipe1, nwp_datapipe2 = nwp_datapipe.fork(2, buffer_size=3)
 
     t0 = pd.Timestamp(ds_nwp.init_time_utc.values[3])


### PR DESCRIPTION
Fix assumption causing buffer overflow. Previously we always assumed we would slice in time before slicing in space. When diffing the accumulated variables that order is less efficient than slicing in space and then slicing in time (where we need to load data).

This pull request means we can do slicing in either order.


Also slight tidy up to address warning about upcoming version of pandas

