### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-ocf_datapipes/training/pvnet.py @dfulu
-ocf_datapipes/training/* @jacobbieker


### PR DESCRIPTION
# Pull Request

## Description

The github CODEOWNERS file was out of date and since it isn't used as standard in other OCF repos it will be removed for now until a decision is made on whether to use CODEOWNERS more generally in OCF repos 

