### PR TITLE
Include trigonometric time features

### DIFF
--- a/ocf_datapipes/batch/batches.py
+++ b/ocf_datapipes/batch/batches.py
@@ -118,6 +118,15 @@ class BatchKey(Enum):
     gsp_x_osgb_fourier = auto()
     gsp_time_utc_fourier = auto()  # (batch_size, time, n_fourier_features)
 
+    # -------------- TIME -------------------------------------------
+    # Sine and cosine of date of year and time of day at every timestep.
+    # shape = (batch_size, n_timesteps)
+    # This is calculated for wind only inside datapipes.
+    wind_date_sin = auto()
+    wind_date_cos = auto()
+    wind_time_sin = auto()
+    wind_time_cos = auto()
+
     # -------------- SUN --------------------------------------------
     # Solar position at every timestep. shape = (batch_size, n_timesteps)
     # The solar position data comes from two alternative sources: either the Sun pre-prepared

--- a/ocf_datapipes/training/windnet.py
+++ b/ocf_datapipes/training/windnet.py
@@ -219,7 +219,7 @@ class ConvertToNumpyBatchIterDataPipe(IterDataPipe):
             )
             # combined_datapipe = MergeNumpyModalities(numpy_modalities).add_sun_position(
             #    modality_name="wind"
-            #)
+            # )
 
             # logger.info("Filtering out samples with no data")
             # if self.check_satellite_no_zeros:

--- a/ocf_datapipes/training/windnet.py
+++ b/ocf_datapipes/training/windnet.py
@@ -213,11 +213,15 @@ class ConvertToNumpyBatchIterDataPipe(IterDataPipe):
                 numpy_modalities.append(datapipes_dict["wind"].convert_wind_to_numpy_batch())
 
             logger.debug("Combine all the data sources")
-            combined_datapipe = MergeNumpyModalities(numpy_modalities).add_sun_position(
+            logger.debug("Adding trigonometric date and time")
+            combined_datapipe = MergeNumpyModalities(numpy_modalities).add_trigonometric_date_time(
                 modality_name="wind"
             )
+            # combined_datapipe = MergeNumpyModalities(numpy_modalities).add_sun_position(
+            #    modality_name="wind"
+            #)
 
-            logger.info("Filtering out samples with no data")
+            # logger.info("Filtering out samples with no data")
             # if self.check_satellite_no_zeros:
             # in production we don't want any nans in the satellite data
             #    combined_datapipe = combined_datapipe.map(check_nans_in_satellite_data)

--- a/ocf_datapipes/transform/numpy_batch/__init__.py
+++ b/ocf_datapipes/transform/numpy_batch/__init__.py
@@ -2,5 +2,5 @@
 
 from .add_fourier_space_time import AddFourierSpaceTimeIterDataPipe as AddFourierSpaceTime
 from .add_topographic_data import AddTopographicDataIterDataPipe as AddTopographicData
-from .sun_position import AddSunPositionIterDataPipe as AddSunPosition
 from .datetime_features import AddTrigonometricDateTimeIterDataPipe as AddTrigonometricDateTime
+from .sun_position import AddSunPositionIterDataPipe as AddSunPosition

--- a/ocf_datapipes/transform/numpy_batch/__init__.py
+++ b/ocf_datapipes/transform/numpy_batch/__init__.py
@@ -3,3 +3,4 @@
 from .add_fourier_space_time import AddFourierSpaceTimeIterDataPipe as AddFourierSpaceTime
 from .add_topographic_data import AddTopographicDataIterDataPipe as AddTopographicData
 from .sun_position import AddSunPositionIterDataPipe as AddSunPosition
+from .datetime_features import AddTrigonometricDateTimeIterDataPipe as AddTrigonometricDateTime

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -7,12 +7,12 @@ from ocf_datapipes.batch import BatchKey
 
 
 def _get_date_time_in_pi(dt):
-    day_of_year = (dt - dt.astype('datetime64[Y]')).astype(int)
-    minute_of_day = (dt - dt.astype('datetime64[D]')).astype(int)
+    day_of_year = (dt - dt.astype("datetime64[Y]")).astype(int)
+    minute_of_day = (dt - dt.astype("datetime64[D]")).astype(int)
 
     # converting into positions on sin-cos circle
-    time_in_pi = (2*np.pi) * (minute_of_day / (24*3600))
-    date_in_pi = (2*np.pi) * (day_of_year / (365*24*3600))
+    time_in_pi = (2 * np.pi) * (minute_of_day / (24 * 3600))
+    date_in_pi = (2 * np.pi) * (day_of_year / (365 * 24 * 3600))
 
     return date_in_pi, time_in_pi
 

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -42,22 +42,9 @@ class AddTrigonometricDateTimeIterDataPipe(IterDataPipe):
         for np_batch in self.source_datapipe:
             time_utc = np_batch[BatchKey.wind_time_utc]
 
-            # Check if the input is batched
-            # time_utc could have shape (batch_size, n_times) or (n_times,)
-            assert len(time_utc.shape) in [1, 2]
-            is_batched = len(time_utc.shape) == 2
+            times: NDArray[np.datetime64] = time_utc.astype("datetime64[s]")
 
-            times = time_utc.astype("datetime64[s]")
-
-            if is_batched:
-                time_in_pi = np.full_like(time_utc, fill_value=np.nan).astype(np.float32)
-                date_in_pi = np.full_like(time_utc, fill_value=np.nan).astype(np.float32)
-
-                # Loop round each example to get converted time values
-                for example_idx, dt in enumerate(times):
-                    date_in_pi[example_idx], time_in_pi[example_idx] = _get_date_time_in_pi(dt)
-            else:
-                date_in_pi, time_in_pi = _get_date_time_in_pi(times)
+            date_in_pi, time_in_pi = _get_date_time_in_pi(times)
 
             # Store
             date_sin_batch_key = BatchKey[self.modality_name + "_date_sin"]

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -1,12 +1,13 @@
 """Datapipes to add Sun position to NumpyBatch"""
 
 import numpy as np
+from numpy.typing import NDArray
 from torch.utils.data import IterDataPipe, functional_datapipe
 
 from ocf_datapipes.batch import BatchKey
 
 
-def _get_date_time_in_pi(dt):
+def _get_date_time_in_pi(dt: NDArray[np.datetime64])) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     day_of_year = (dt - dt.astype("datetime64[Y]")).astype(int)
     minute_of_day = (dt - dt.astype("datetime64[D]")).astype(int)
 

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -1,4 +1,4 @@
-"""Datapipes to add Sun position to NumpyBatch"""
+"""Datapipes to trigonometric date and time to NumpyBatch"""
 
 import numpy as np
 from numpy.typing import NDArray

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -7,7 +7,7 @@ from torch.utils.data import IterDataPipe, functional_datapipe
 from ocf_datapipes.batch import BatchKey
 
 
-def _get_date_time_in_pi(dt: NDArray[np.datetime64])) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+def _get_date_time_in_pi(dt: NDArray[np.datetime64]) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     day_of_year = (dt - dt.astype("datetime64[Y]")).astype(int)
     minute_of_day = (dt - dt.astype("datetime64[D]")).astype(int)
 

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -7,7 +7,9 @@ from torch.utils.data import IterDataPipe, functional_datapipe
 from ocf_datapipes.batch import BatchKey
 
 
-def _get_date_time_in_pi(dt: NDArray[np.datetime64]) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+def _get_date_time_in_pi(
+    dt: NDArray[np.datetime64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     day_of_year = (dt - dt.astype("datetime64[Y]")).astype(int)
     minute_of_day = (dt - dt.astype("datetime64[D]")).astype(int)
 

--- a/ocf_datapipes/transform/numpy_batch/datetime_features.py
+++ b/ocf_datapipes/transform/numpy_batch/datetime_features.py
@@ -1,0 +1,70 @@
+"""Datapipes to add Sun position to NumpyBatch"""
+
+import numpy as np
+from torch.utils.data import IterDataPipe, functional_datapipe
+
+from ocf_datapipes.batch import BatchKey
+
+
+def _get_date_time_in_pi(dt):
+    day_of_year = (dt - dt.astype('datetime64[Y]')).astype(int)
+    minute_of_day = (dt - dt.astype('datetime64[D]')).astype(int)
+
+    # converting into positions on sin-cos circle
+    time_in_pi = (2*np.pi) * (minute_of_day / (24*3600))
+    date_in_pi = (2*np.pi) * (day_of_year / (365*24*3600))
+
+    return date_in_pi, time_in_pi
+
+
+@functional_datapipe("add_trigonometric_date_time")
+class AddTrigonometricDateTimeIterDataPipe(IterDataPipe):
+    """Adds the trigonometric encodings of date of year, time of day to the NumpyBatch"""
+
+    def __init__(self, source_datapipe: IterDataPipe, modality_name: str):
+        """
+        Adds the sine and cosine of time to the NumpyBatch
+
+        Args:
+            source_datapipe: Datapipe of NumpyBatch
+            modality_name: Modality to add the time for
+        """
+        self.source_datapipe = source_datapipe
+        self.modality_name = modality_name
+        assert self.modality_name in [
+            "wind",
+        ], f"Trigonometric time not implemented for {self.modality_name}"
+
+    def __iter__(self):
+        for np_batch in self.source_datapipe:
+            time_utc = np_batch[BatchKey.wind_time_utc]
+
+            # Check if the input is batched
+            # time_utc could have shape (batch_size, n_times) or (n_times,)
+            assert len(time_utc.shape) in [1, 2]
+            is_batched = len(time_utc.shape) == 2
+
+            times = time_utc.astype("datetime64[s]")
+
+            if is_batched:
+                time_in_pi = np.full_like(time_utc, fill_value=np.nan).astype(np.float32)
+                date_in_pi = np.full_like(time_utc, fill_value=np.nan).astype(np.float32)
+
+                # Loop round each example to get converted time values
+                for example_idx, dt in enumerate(times):
+                    date_in_pi[example_idx], time_in_pi[example_idx] = _get_date_time_in_pi(dt)
+            else:
+                date_in_pi, time_in_pi = _get_date_time_in_pi(times)
+
+            # Store
+            date_sin_batch_key = BatchKey[self.modality_name + "_date_sin"]
+            date_cos_batch_key = BatchKey[self.modality_name + "_date_cos"]
+            time_sin_batch_key = BatchKey[self.modality_name + "_time_sin"]
+            time_cos_batch_key = BatchKey[self.modality_name + "_time_cos"]
+
+            np_batch[date_sin_batch_key] = np.sin(date_in_pi)
+            np_batch[date_cos_batch_key] = np.cos(date_in_pi)
+            np_batch[time_sin_batch_key] = np.sin(time_in_pi)
+            np_batch[time_cos_batch_key] = np.cos(time_in_pi)
+
+            yield np_batch

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -25,8 +25,12 @@ def test_get_date_time_in_pi():
     times = np.array([datetime.fromisoformat(time) for time in times], dtype="datetime64[s]")
 
     date_in_pi, time_in_pi = _get_date_time_in_pi(times)
-
-    assert np.isclose(np.cos(time_in_pi), np.cos(expected_times_in_pi), atol=1e-04).all()
-    assert np.isclose(np.sin(time_in_pi), np.sin(expected_times_in_pi), atol=1e-04).all()
-    assert np.isclose(np.cos(date_in_pi), np.cos(expected_times_in_pi), atol=0.01).all()
-    assert np.isclose(np.sin(date_in_pi), np.sin(expected_times_in_pi), atol=0.02).all()
+    
+    # Note on precision: times are compared with tolerance equivalent to 1 second,
+    # dates are compared with tolerance equivalent to 5 minutes
+    # None of the data we use has a higher time resolution, so this is a good test of
+    # whether not accounting for leap years breaks things
+    assert np.isclose(np.cos(time_in_pi), np.cos(expected_times_in_pi), atol=7.3e-05).all()
+    assert np.isclose(np.sin(time_in_pi), np.sin(expected_times_in_pi), atol=7.3e-05).all()
+    assert np.isclose(np.cos(date_in_pi), np.cos(expected_times_in_pi), atol=0.02182).all()
+    assert np.isclose(np.sin(date_in_pi), np.sin(expected_times_in_pi), atol=0.02182).all()

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -25,7 +25,7 @@ def test_get_date_time_in_pi():
     times = np.array([datetime.fromisoformat(time) for time in times], dtype="datetime64[s]")
 
     date_in_pi, time_in_pi = _get_date_time_in_pi(times)
-    
+
     # Note on precision: times are compared with tolerance equivalent to 1 second,
     # dates are compared with tolerance equivalent to 5 minutes
     # None of the data we use has a higher time resolution, so this is a good test of

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -1,0 +1,34 @@
+import numpy as np
+from datetime import datetime
+
+from ocf_datapipes.transform.numpy_batch import AddTrigonometricDateTime
+
+from ocf_datapipes.transform.numpy_batch.datetime_features import _get_date_time_in_pi
+
+
+def test_get_date_time_in_pi():
+    times = [
+              "2020-01-01T00:00:01", "2020-04-01T06:00:00",
+              "2020-07-01T12:00:00", "2020-09-30T18:00:00",
+              "2020-12-31T23:59:59",
+              "2021-01-01T00:00:01", "2021-04-02T06:00:00",
+              "2021-07-02T12:00:00", "2021-10-01T18:00:00",
+              "2021-12-31T23:59:59"
+             ]
+
+    expected_times_in_pi = [0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi]*2
+
+    times = np.array([datetime.fromisoformat(time) for time in times], dtype="datetime64[s]")
+
+    date_in_pi, time_in_pi = _get_date_time_in_pi(times)
+
+    assert np.isclose(np.cos(time_in_pi), np.cos(expected_times_in_pi), atol=1e-04).all()
+    assert np.isclose(np.sin(time_in_pi), np.sin(expected_times_in_pi), atol=1e-04).all()
+    assert np.isclose(np.cos(date_in_pi), np.cos(expected_times_in_pi), atol=0.01).all()
+    assert np.isclose(np.sin(date_in_pi), np.sin(expected_times_in_pi), atol=0.02).all()
+
+
+def test_add_trigonometric_datetime(combined_datapipe):
+    combined_datapipe = AddTrigonometricDateTime(combined_datapipe, modality_name="wind")
+    data = next(iter(combined_datapipe))
+    assert data is not None

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -8,15 +8,19 @@ from ocf_datapipes.transform.numpy_batch.datetime_features import _get_date_time
 
 def test_get_date_time_in_pi():
     times = [
-              "2020-01-01T00:00:01", "2020-04-01T06:00:00",
-              "2020-07-01T12:00:00", "2020-09-30T18:00:00",
-              "2020-12-31T23:59:59",
-              "2021-01-01T00:00:01", "2021-04-02T06:00:00",
-              "2021-07-02T12:00:00", "2021-10-01T18:00:00",
-              "2021-12-31T23:59:59"
-             ]
+        "2020-01-01T00:00:01",
+        "2020-04-01T06:00:00",
+        "2020-07-01T12:00:00",
+        "2020-09-30T18:00:00",
+        "2020-12-31T23:59:59",
+        "2021-01-01T00:00:01",
+        "2021-04-02T06:00:00",
+        "2021-07-02T12:00:00",
+        "2021-10-01T18:00:00",
+        "2021-12-31T23:59:59",
+    ]
 
-    expected_times_in_pi = [0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi]*2
+    expected_times_in_pi = [0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi] * 2
 
     times = np.array([datetime.fromisoformat(time) for time in times], dtype="datetime64[s]")
 

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -30,9 +30,3 @@ def test_get_date_time_in_pi():
     assert np.isclose(np.sin(time_in_pi), np.sin(expected_times_in_pi), atol=1e-04).all()
     assert np.isclose(np.cos(date_in_pi), np.cos(expected_times_in_pi), atol=0.01).all()
     assert np.isclose(np.sin(date_in_pi), np.sin(expected_times_in_pi), atol=0.02).all()
-
-
-def test_add_trigonometric_datetime(combined_datapipe):
-    combined_datapipe = AddTrigonometricDateTime(combined_datapipe, modality_name="wind")
-    data = next(iter(combined_datapipe))
-    assert data is not None

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -1,28 +1,21 @@
 import numpy as np
-from datetime import datetime
-
-from ocf_datapipes.transform.numpy_batch import AddTrigonometricDateTime
 
 from ocf_datapipes.transform.numpy_batch.datetime_features import _get_date_time_in_pi
 
 
 def test_get_date_time_in_pi():
-    times = [
-        "2020-01-01T00:00:01",
-        "2020-04-01T06:00:00",
-        "2020-07-01T12:00:00",
-        "2020-09-30T18:00:00",
-        "2020-12-31T23:59:59",
-        "2021-01-01T00:00:01",
-        "2021-04-02T06:00:00",
-        "2021-07-02T12:00:00",
-        "2021-10-01T18:00:00",
-        "2021-12-31T23:59:59",
-    ]
+    times = np.array([
+              "2020-01-01T00:00:00", "2020-04-01T06:00:00",
+              "2020-07-01T12:00:00", "2020-09-30T18:00:00",
+              "2020-12-31T23:59:59",
+              "2021-01-01T00:00:00", "2021-04-02T06:00:00",
+              "2021-07-02T12:00:00", "2021-10-01T18:00:00",
+              "2021-12-31T23:59:59"
+             ]).reshape((2, 5))
 
-    expected_times_in_pi = [0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi] * 2
+    expected_times_in_pi = np.array([0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi] * 2).reshape((2,5))
 
-    times = np.array([datetime.fromisoformat(time) for time in times], dtype="datetime64[s]")
+    times = times.astype("datetime64[s]")
 
     date_in_pi, time_in_pi = _get_date_time_in_pi(times)
 
@@ -34,3 +27,9 @@ def test_get_date_time_in_pi():
     assert np.isclose(np.sin(time_in_pi), np.sin(expected_times_in_pi), atol=7.3e-05).all()
     assert np.isclose(np.cos(date_in_pi), np.cos(expected_times_in_pi), atol=0.02182).all()
     assert np.isclose(np.sin(date_in_pi), np.sin(expected_times_in_pi), atol=0.02182).all()
+
+    # 1D array test
+    assert np.isclose(np.cos(time_in_pi[0]), np.cos(expected_times_in_pi[0]), atol=7.3e-05).all()
+    assert np.isclose(np.sin(time_in_pi[0]), np.sin(expected_times_in_pi[0]), atol=7.3e-05).all()
+    assert np.isclose(np.cos(date_in_pi[0]), np.cos(expected_times_in_pi[0]), atol=0.02182).all()
+    assert np.isclose(np.sin(date_in_pi[0]), np.sin(expected_times_in_pi[0]), atol=0.02182).all()

--- a/tests/transform/numpy_batch/test_datetime_features.py
+++ b/tests/transform/numpy_batch/test_datetime_features.py
@@ -4,16 +4,24 @@ from ocf_datapipes.transform.numpy_batch.datetime_features import _get_date_time
 
 
 def test_get_date_time_in_pi():
-    times = np.array([
-              "2020-01-01T00:00:00", "2020-04-01T06:00:00",
-              "2020-07-01T12:00:00", "2020-09-30T18:00:00",
-              "2020-12-31T23:59:59",
-              "2021-01-01T00:00:00", "2021-04-02T06:00:00",
-              "2021-07-02T12:00:00", "2021-10-01T18:00:00",
-              "2021-12-31T23:59:59"
-             ]).reshape((2, 5))
+    times = np.array(
+        [
+            "2020-01-01T00:00:00",
+            "2020-04-01T06:00:00",
+            "2020-07-01T12:00:00",
+            "2020-09-30T18:00:00",
+            "2020-12-31T23:59:59",
+            "2021-01-01T00:00:00",
+            "2021-04-02T06:00:00",
+            "2021-07-02T12:00:00",
+            "2021-10-01T18:00:00",
+            "2021-12-31T23:59:59",
+        ]
+    ).reshape((2, 5))
 
-    expected_times_in_pi = np.array([0, 0.5*np.pi, np.pi, 1.5*np.pi, 2*np.pi] * 2).reshape((2,5))
+    expected_times_in_pi = np.array([0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2 * np.pi] * 2).reshape(
+        (2, 5)
+    )
 
     times = times.astype("datetime64[s]")
 


### PR DESCRIPTION
# Pull Request

## Description

Adding calculation and support for trigonometric time features (sine and cosine of time of year and time of day, 4 features total) for windnet. Currently calculated only from windnet based on wind's time index

NB: it replaces add_sun_position at `MergeNumpyModalities` in `windnet.py`; ultimately decided it's never used for wind, so not a loss. 

Added tests to check time transform works as expected

## How Has This Been Tested?

Ran training of windnet with time features included

- [X] Yes


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
