### PR TITLE
Add check for lat long location in satellite data spatial slicing

### DIFF
--- a/ocf_datapipes/select/select_spatial_slice.py
+++ b/ocf_datapipes/select/select_spatial_slice.py
@@ -103,24 +103,33 @@ def _get_idx_of_pixel_closest_to_poi(
 
 def _get_idx_of_pixel_closest_to_poi_geostationary(
     xr_data: xr.DataArray,
-    center_osgb: Location,
+    center_coordinate: Location,
 ) -> Location:
     """
     Return x and y index location of pixel at center of region of interest.
 
     Args:
         xr_data: Xarray dataset
-        center_osgb: Center in OSGB coordinates
+        center_coordinate: Central coordinate
 
     Returns:
         Location for the center pixel in geostationary coordinates
     """
-
     xr_coords, xr_x_dim, xr_y_dim = spatial_coord_type(xr_data)
+    if center_coordinate.coordinate_system == "osgb":
+        x, y = osgb_to_geostationary_area_coords(x=center_coordinate.x, 
+                                                 y=center_coordinate.y,
+                                                 xr_data=xr_data)
+    elif center_coordinate.coordinate_system == "lon_lat":
+        x, y = lon_lat_to_geostationary_area_coords(x=center_coordinate.x,
+                                                    y=center_coordinate.y,
+                                                    xr_data=xr_data)
+    else:
+        raise NotImplementedError(f"Only 'osgb' and 'lon_lat' location coordinates are \
+                                  supported in conversion to geostationary \
+                                   - not '{center_coordinate.coordinate_system}'")
 
-    x, y = osgb_to_geostationary_area_coords(x=center_osgb.x, y=center_osgb.y, xr_data=xr_data)
     center_geostationary = Location(x=x, y=y, coordinate_system="geostationary")
-
     # Check that the requested point lies within the data
     assert xr_data[xr_x_dim].min() < x < xr_data[xr_x_dim].max()
     assert xr_data[xr_y_dim].min() < y < xr_data[xr_y_dim].max()
@@ -390,7 +399,7 @@ def select_spatial_slice_pixels(
         if xr_coords == "geostationary":
             center_idx: Location = _get_idx_of_pixel_closest_to_poi_geostationary(
                 xr_data=xr_data,
-                center_osgb=location,
+                center_coordinate=location,
             )
         else:
             center_idx: Location = _get_idx_of_pixel_closest_to_poi(

--- a/ocf_datapipes/select/select_spatial_slice.py
+++ b/ocf_datapipes/select/select_spatial_slice.py
@@ -117,17 +117,19 @@ def _get_idx_of_pixel_closest_to_poi_geostationary(
     """
     xr_coords, xr_x_dim, xr_y_dim = spatial_coord_type(xr_data)
     if center_coordinate.coordinate_system == "osgb":
-        x, y = osgb_to_geostationary_area_coords(x=center_coordinate.x, 
-                                                 y=center_coordinate.y,
-                                                 xr_data=xr_data)
+        x, y = osgb_to_geostationary_area_coords(
+            x=center_coordinate.x, y=center_coordinate.y, xr_data=xr_data
+        )
     elif center_coordinate.coordinate_system == "lon_lat":
-        x, y = lon_lat_to_geostationary_area_coords(x=center_coordinate.x,
-                                                    y=center_coordinate.y,
-                                                    xr_data=xr_data)
+        x, y = lon_lat_to_geostationary_area_coords(
+            x=center_coordinate.x, y=center_coordinate.y, xr_data=xr_data
+        )
     else:
-        raise NotImplementedError(f"Only 'osgb' and 'lon_lat' location coordinates are \
+        raise NotImplementedError(
+            f"Only 'osgb' and 'lon_lat' location coordinates are \
                                   supported in conversion to geostationary \
-                                   - not '{center_coordinate.coordinate_system}'")
+                                   - not '{center_coordinate.coordinate_system}'"
+        )
 
     center_geostationary = Location(x=x, y=y, coordinate_system="geostationary")
     # Check that the requested point lies within the data

--- a/tests/select/test_select_spatial_slice.py
+++ b/tests/select/test_select_spatial_slice.py
@@ -161,6 +161,7 @@ def test_select_spatial_slice_meters_icon_global(passiv_datapipe, icon_global_da
     assert len(data.longitude) == 49
     assert len(data.latitude) == 49
 
+
 def test_get_idx_of_pixel_closest_to_poi_geostationary_lon_lat_location():
     # Create dummy data
     x = np.arange(5000000, -5000000, -5000)
@@ -175,12 +176,15 @@ def test_get_idx_of_pixel_closest_to_poi_geostationary_lon_lat_location():
             y_geostationary=(["y_geostationary"], y),
         ),
     )
-    xr_data.attrs["area"] = 'msg_seviri_iodc_3km:\n  description: MSG SEVIRI Indian Ocean Data Coverage service area definition with\n    3 km resolution\n  projection:\n    proj: geos\n    lon_0: 41.5\n    h: 35785831\n    x_0: 0\n    y_0: 0\n    a: 6378169\n    rf: 295.488065897014\n    no_defs: null\n    type: crs\n  shape:\n    height: 3712\n    width: 3712\n  area_extent:\n    lower_left_xy: [5000000, 5000000]\n    upper_right_xy: [-5000000, -5000000]\n    units: m\n'
-
+    xr_data.attrs["area"] = (
+        "msg_seviri_iodc_3km:\n  description: MSG SEVIRI Indian Ocean Data Coverage service area definition with\n    3 km resolution\n  projection:\n    proj: geos\n    lon_0: 41.5\n    h: 35785831\n    x_0: 0\n    y_0: 0\n    a: 6378169\n    rf: 295.488065897014\n    no_defs: null\n    type: crs\n  shape:\n    height: 3712\n    width: 3712\n  area_extent:\n    lower_left_xy: [5000000, 5000000]\n    upper_right_xy: [-5000000, -5000000]\n    units: m\n"
+    )
 
     center = Location(x=77.1, y=28.6, coordinate_system="lon_lat")
 
-    location_center_idx = _get_idx_of_pixel_closest_to_poi_geostationary(xr_data=xr_data, center_coordinate=center)
+    location_center_idx = _get_idx_of_pixel_closest_to_poi_geostationary(
+        xr_data=xr_data, center_coordinate=center
+    )
 
-    assert location_center_idx.coordinate_system == 'idx'
+    assert location_center_idx.coordinate_system == "idx"
     assert location_center_idx.x == 2000


### PR DESCRIPTION
# Pull Request

## Description

For satellite data spatial slicing we currently assume that the central coordinate of interest will be in an osgb coordinate system, which is UK specific, but coordinates of interest can also be in lat long for example for sites outside of the UK this is common. This change will add a check for what coordinate system is being used in the location of interest and then use the appropriate conversion function to geostationary coords. 


## How Has This Been Tested?
Adding a unit test for this case and running the pipeline on a small sample of data 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
