### PR TITLE
FIX batchkey enum bug

### DIFF
--- a/ocf_datapipes/batch/batches.py
+++ b/ocf_datapipes/batch/batches.py
@@ -118,15 +118,6 @@ class BatchKey(Enum):
     gsp_x_osgb_fourier = auto()
     gsp_time_utc_fourier = auto()  # (batch_size, time, n_fourier_features)
 
-    # -------------- TIME -------------------------------------------
-    # Sine and cosine of date of year and time of day at every timestep.
-    # shape = (batch_size, n_timesteps)
-    # This is calculated for wind only inside datapipes.
-    wind_date_sin = auto()
-    wind_date_cos = auto()
-    wind_time_sin = auto()
-    wind_time_cos = auto()
-
     # -------------- SUN --------------------------------------------
     # Solar position at every timestep. shape = (batch_size, n_timesteps)
     # The solar position data comes from two alternative sources: either the Sun pre-prepared
@@ -207,6 +198,15 @@ class BatchKey(Enum):
 
     wind_solar_azimuth = auto()
     wind_solar_elevation = auto()
+
+    # -------------- TIME -------------------------------------------
+    # Sine and cosine of date of year and time of day at every timestep.
+    # shape = (batch_size, n_timesteps)
+    # This is calculated for wind only inside datapipes.
+    wind_date_sin = auto()
+    wind_date_cos = auto()
+    wind_time_sin = auto()
+    wind_time_cos = auto()
 
 
 class NWPBatchKey(Enum):


### PR DESCRIPTION
# Pull Request

On previous merge I added new batchkeys in the middle of the class, which is enumerated, so it bumps all the keys after the new ones 4 down when unpacking premade batches, leading to errors. This PR puts the keys at the bottom, where they should've been in the first place

I *think* this only affects batches stored as tensors, as .netcdf batches have labels that get converted to BatchKeys.

## How Has This Been Tested?

Ran the full battery of PVNet tests locally, for two versions of PVNet: current and with [this fix](https://github.com/openclimatefix/PVNet/pull/242).

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
