### PR TITLE
change ml_id infills to zero from nan

### DIFF
--- a/ocf_datapipes/load/pv/pv.py
+++ b/ocf_datapipes/load/pv/pv.py
@@ -225,7 +225,7 @@ def _load_pv_metadata(
 
     # Add ml_id column if not in metadata already
     if "ml_id" not in df_metadata.columns:
-        df_metadata["ml_id"] = np.nan
+        df_metadata["ml_id"] = 0.0
 
     if label == "solar_sheffield_passiv":
         # Add capacity in watts

--- a/ocf_datapipes/load/pv/pv.py
+++ b/ocf_datapipes/load/pv/pv.py
@@ -225,7 +225,7 @@ def _load_pv_metadata(
 
     # Add ml_id column if not in metadata already
     if "ml_id" not in df_metadata.columns:
-        df_metadata["ml_id"] = 0.0
+        df_metadata["ml_id"] = -1.0
 
     if label == "solar_sheffield_passiv":
         # Add capacity in watts

--- a/ocf_datapipes/load/wind/wind.py
+++ b/ocf_datapipes/load/wind/wind.py
@@ -73,7 +73,7 @@ def _load_wind_metadata(filename: str) -> pd.DataFrame:
 
     # Add ml_id column if not in metadata already
     if "ml_id" not in df_metadata.columns:
-        df_metadata["ml_id"] = np.nan
+        df_metadata["ml_id"] = 0.0
 
     _log.info(f"Found {len(df_metadata)} Wind systems in {filename}")
 

--- a/ocf_datapipes/load/wind/wind.py
+++ b/ocf_datapipes/load/wind/wind.py
@@ -73,7 +73,7 @@ def _load_wind_metadata(filename: str) -> pd.DataFrame:
 
     # Add ml_id column if not in metadata already
     if "ml_id" not in df_metadata.columns:
-        df_metadata["ml_id"] = 0.0
+        df_metadata["ml_id"] = -1.0
 
     _log.info(f"Found {len(df_metadata)} Wind systems in {filename}")
 


### PR DESCRIPTION
# Pull Request

## Description
When ml_id is not in metadata, we create a new column filled with `np.nan`, which will later be infilled by zeroes over and over. This PR creates it as a column of -1 to signal that this is not a normal ml_id

Fixes #321 

## How Has This Been Tested?
Ran batch creation and later training with this change for windnet; change for pvnet is the same

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
