### PR TITLE
Check start_time < end_time when selecting valid nwp t0 slices

### DIFF
--- a/ocf_datapipes/select/find_contiguous_t0_time_periods.py
+++ b/ocf_datapipes/select/find_contiguous_t0_time_periods.py
@@ -255,5 +255,6 @@ def find_contiguous_t0_periods_nwp(
         end_this_period = dt_init + max_staleness
 
     contiguous_periods += [[start_this_period, end_this_period]]
-
-    return pd.DataFrame(contiguous_periods, columns=["start_dt", "end_dt"])
+    contiguous_time_periods = pd.DataFrame(contiguous_periods, columns=["start_dt", "end_dt"])
+    assert (contiguous_time_periods["start_dt"] <= contiguous_time_periods["end_dt"]).all()
+    return contiguous_time_periods


### PR DESCRIPTION
# Pull Request

## Description

Adding start_time < end_time to `find_contiguous_t0_periods_nwp`; other data sources receive this check but nwps don't

Fixes #341

## How Has This Been Tested?

Ran small batch creation with this on

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
