### PR TITLE
Remove unused configs

### DIFF
--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -279,13 +279,6 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
         "values can be interpolated, and the extra minutes removed. This is "
         "because some live data takes ~1 hour to come in.",
     )
-    get_center: bool = Field(
-        False,
-        description="If the batches are centered on one Wind system (or not). "
-        "The other options is to have one GSP at the center of a batch. "
-        "Typically, get_center would be set to true if and only if "
-        "WindDataSource is used to define the geospatial positions of each example.",
-    )
 
     time_resolution_minutes: int = Field(
         15,
@@ -336,13 +329,6 @@ class PV(
     )
     pv_image_size_meters_height: int = METERS_PER_ROI
     pv_image_size_meters_width: int = METERS_PER_ROI
-    get_center: bool = Field(
-        False,
-        description="If the batches are centered on one PV system (or not). "
-        "The other options is to have one GSP at the center of a batch. "
-        "Typically, get_center would be set to true if and only if "
-        "PVDataSource is used to define the geospatial positions of each example.",
-    )
 
     pv_filename: Optional[str] = Field(
         None,
@@ -405,13 +391,6 @@ class Sensor(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames):
 
     sensor_image_size_meters_height: int = METERS_PER_ROI
     sensor_image_size_meters_width: int = METERS_PER_ROI
-    get_center: bool = Field(
-        False,
-        description="If the batches are centered on one Sensor system (or not). "
-        "The other options is to have one GSP at the center of a batch. "
-        "Typically, get_center would be set to true if and only if "
-        "SensorDataSource is used to define the geospatial positions of each example.",
-    )
 
     sensor_filename: str = Field(
         None,
@@ -759,12 +738,6 @@ class InputData(Base):
         ge=0,
         description="how many historic minutes are used. "
         "This sets the default for all the data sources if they are not set.",
-    )
-    data_source_which_defines_geospatial_locations: str = Field(
-        "gsp",
-        description=(
-            "The name of the DataSource which will define the geospatial position of each example."
-        ),
     )
 
     @property

--- a/tests/data/configs/on_premises.yaml
+++ b/tests/data/configs/on_premises.yaml
@@ -40,7 +40,6 @@ input_data:
       - label: pvoutput.org
         pv_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/PVOutput.org/UK_PV_timeseries_batch.nc
         pv_metadata_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/PVOutput.org/UK_PV_metadata.csv
-    get_center: false
     history_minutes: 90
     forecast_minutes: 360
     log_level: "INFO"

--- a/tests/data/configs/test.yaml
+++ b/tests/data/configs/test.yaml
@@ -27,7 +27,6 @@ input_data:
       - label: india
         wind_filename: tests/data/wind/wind_test_data.nc
         wind_metadata_filename: tests/data/wind/wind_metadata.csv
-    get_center: false
     wind_image_size_meters_height: 10000000
     wind_image_size_meters_width: 10000000
     n_wind_systems_per_example: 1
@@ -40,7 +39,6 @@ input_data:
       - label: pvoutput.org
         pv_filename: tests/data/pv/pvoutput/test.nc
         pv_metadata_filename: tests/data/pv/pvoutput/UK_PV_metadata.csv
-    get_center: false
     pv_image_size_meters_height: 10000000
     pv_image_size_meters_width: 10000000
     n_pv_systems_per_example: 32

--- a/tests/data/configs/wind_test.yaml
+++ b/tests/data/configs/wind_test.yaml
@@ -23,7 +23,6 @@ input_data:
       - label: pvoutput.org
         pv_filename: tests/data/pv/pvoutput/test.nc
         pv_metadata_filename: tests/data/pv/pvoutput/UK_PV_metadata.csv
-    get_center: false
     pv_image_size_meters_height: 10000000
     pv_image_size_meters_width: 10000000
     n_pv_systems_per_example: 32


### PR DESCRIPTION
# Pull Request

## Description
Strips out `get_center` and `data_source_which_defines_geospatial_locations` arguments from configs and tests, as these are not implemented and never used.

Has a [sister PR in pvnet](https://github.com/openclimatefix/PVNet/pull/246) that strips those parameters out of the only test they are present in.

Fixes #324

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
