### PR TITLE
Enforce forecast and history duration divisibility by time resolution

### DIFF
--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -870,7 +870,7 @@ class Configuration(Base):
         path_attrs = [
             "pv.pv_filename",
             "pv.pv_metadata_filename",
-            "satellite.satellite_zarr_path",k
+            "satellite.satellite_zarr_path",
             "hrvsatellite.hrvsatellite_zarr_path",
             "nwp.nwp_zarr_path",
             "gsp.gsp_zarr_path",

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Union
 import git
 import numpy as np
 from pathy import Pathy
-from pydantic import BaseModel, Field, RootModel, model_validator, field_validator, ValidationInfo
+from pydantic import BaseModel, Field, RootModel, ValidationInfo, field_validator, model_validator
 
 # nowcasting_dataset imports
 from ocf_datapipes.utils.consts import (
@@ -284,7 +284,7 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
         description="The temporal resolution (in minutes) of the data."
         "Note that this needs to be divisible by 5.",
     )
-    
+
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
         if v % info.data["time_resolution_minutes"] != 0:
@@ -399,7 +399,7 @@ class PV(
             v.pv_metadata_filename = None
 
         return v
-    
+
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
         if v % info.data["time_resolution_minutes"] != 0:
@@ -638,7 +638,7 @@ class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin
             logger.warning(message)
             assert Exception(message)
         return v
-    
+
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
         if v % info.data["time_resolution_minutes"] != 0:

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -287,6 +287,7 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
 
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check forecast length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "Forecast duration must be divisible by time resolution"
             logger.error(message)
@@ -295,6 +296,7 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
 
     @field_validator("history_minutes")
     def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check history length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "History duration must be divisible by time resolution"
             logger.error(message)
@@ -402,6 +404,7 @@ class PV(
 
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check forecast length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "Forecast duration must be divisible by time resolution"
             logger.error(message)
@@ -410,6 +413,7 @@ class PV(
 
     @field_validator("history_minutes")
     def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check history length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "History duration must be divisible by time resolution"
             logger.error(message)
@@ -641,6 +645,7 @@ class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin
 
     @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check forecast length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "Forecast duration must be divisible by time resolution"
             logger.error(message)
@@ -649,6 +654,7 @@ class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin
 
     @field_validator("history_minutes")
     def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        """Check history length requested will give stable number of timesteps"""
         if v % info.data["time_resolution_minutes"] != 0:
             message = "History duration must be divisible by time resolution"
             logger.error(message)

--- a/ocf_datapipes/config/model.py
+++ b/ocf_datapipes/config/model.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Union
 import git
 import numpy as np
 from pathy import Pathy
-from pydantic import BaseModel, Field, RootModel, model_validator, validator
+from pydantic import BaseModel, Field, RootModel, model_validator, field_validator, ValidationInfo
 
 # nowcasting_dataset imports
 from ocf_datapipes.utils.consts import (
@@ -93,8 +93,8 @@ class DataSourceMixin(Base):
 
     log_level: str = Field(
         "DEBUG",
-        description="The logging level for this data source. T"
-        "his is the default value and can be set in each data source",
+        description="The logging level for this data source. "
+        "This is the default value and can be set in each data source",
     )
 
     @property
@@ -139,16 +139,16 @@ class DropoutMixin(Base):
 
     dropout_fraction: float = Field(0, description="Chance of dropout being applied to each sample")
 
-    @validator("dropout_timedeltas_minutes")
-    def dropout_timedeltas_minutes_negative(cls, v):
+    @field_validator("dropout_timedeltas_minutes")
+    def dropout_timedeltas_minutes_negative(cls, v: List[int]) -> List[int]:
         """Validate 'dropout_timedeltas_minutes'"""
         if v is not None:
             for m in v:
                 assert m <= 0
         return v
 
-    @validator("dropout_fraction")
-    def dropout_fraction_valid(cls, v):
+    @field_validator("dropout_fraction")
+    def dropout_fraction_valid(cls, v: float) -> float:
         """Validate 'dropout_fraction'"""
         assert 0 <= v <= 1
         return v
@@ -169,8 +169,8 @@ class SystemDropoutMixin(Base):
     system_dropout_fraction_min: float = Field(0, description="Min chance of system dropout")
     system_dropout_fraction_max: float = Field(0, description="Max chance of system dropout")
 
-    @validator("system_dropout_fraction_min", "system_dropout_fraction_max")
-    def validate_system_dropout_fractions(cls, v):
+    @field_validator("system_dropout_fraction_min", "system_dropout_fraction_max")
+    def validate_system_dropout_fractions(cls, v: float):
         """Validate dropout fraction values"""
         assert 0 <= v <= 1
         return v
@@ -192,8 +192,8 @@ class TimeResolutionMixin(Base):
         "Note that this needs to be divisible by 5.",
     )
 
-    @validator("time_resolution_minutes")
-    def forecast_minutes_divide_by_5(cls, v):
+    @field_validator("time_resolution_minutes")
+    def forecast_minutes_divide_by_5(cls, v: int) -> int:
         """Validate 'forecast_minutes'"""
         assert v % 5 == 0, f"The time resolution ({v}) is not divisible by 5"
         return v
@@ -257,7 +257,6 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
         None,
         description="List of the ML IDs of the Wind systems you'd like to filter to.",
     )
-    time_resolution_minutes: int = Field(15, description="The temporal resolution (in minutes).")
     wind_image_size_meters_height: int = METERS_PER_ROI
     wind_image_size_meters_width: int = METERS_PER_ROI
     n_wind_systems_per_example: int = Field(
@@ -285,6 +284,22 @@ class Wind(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixi
         description="The temporal resolution (in minutes) of the data."
         "Note that this needs to be divisible by 5.",
     )
+    
+    @field_validator("forecast_minutes")
+    def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "Forecast duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
+        return v
+
+    @field_validator("history_minutes")
+    def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "History duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
+        return v
 
 
 class PVFiles(BaseModel):
@@ -305,8 +320,8 @@ class PVFiles(BaseModel):
 
     label: Optional[str] = Field(providers[0], description="Label of where the pv data came from")
 
-    @validator("label")
-    def v_label0(cls, v):
+    @field_validator("label")
+    def v_label0(cls, v: str) -> str:
         """Validate 'label'"""
         if v not in providers:
             message = f"provider {v} not in {providers}"
@@ -383,6 +398,22 @@ class PV(
             v.pv_filename = None
             v.pv_metadata_filename = None
 
+        return v
+    
+    @field_validator("forecast_minutes")
+    def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "Forecast duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
+        return v
+
+    @field_validator("history_minutes")
+    def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "History duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
         return v
 
 
@@ -599,13 +630,29 @@ class NWP(DataSourceMixin, TimeResolutionMixin, XYDimensionalNames, DropoutMixin
         0.1, description="The number of degrees to coarsen the NWP data to"
     )
 
-    @validator("nwp_provider")
-    def validate_nwp_provider(cls, v):
+    @field_validator("nwp_provider")
+    def validate_nwp_provider(cls, v: str) -> str:
         """Validate 'nwp_provider'"""
         if v.lower() not in NWP_PROVIDERS:
             message = f"NWP provider {v} is not in {NWP_PROVIDERS}"
             logger.warning(message)
             assert Exception(message)
+        return v
+    
+    @field_validator("forecast_minutes")
+    def forecast_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "Forecast duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
+        return v
+
+    @field_validator("history_minutes")
+    def history_minutes_divide_by_time_resolution(cls, v: int, info: ValidationInfo) -> int:
+        if v % info.data["time_resolution_minutes"] != 0:
+            message = "History duration must be divisible by time resolution"
+            logger.error(message)
+            raise Exception(message)
         return v
 
 
@@ -668,13 +715,13 @@ class GSP(DataSourceMixin, TimeResolutionMixin, DropoutMixin):
         "Note that this needs to be divisible by 5.",
     )
 
-    @validator("history_minutes")
+    @field_validator("history_minutes")
     def history_minutes_divide_by_30(cls, v):
         """Validate 'history_minutes'"""
         assert v % 30 == 0  # this means it also divides by 5
         return v
 
-    @validator("forecast_minutes")
+    @field_validator("forecast_minutes")
     def forecast_minutes_divide_by_30(cls, v):
         """Validate 'forecast_minutes'"""
         assert v % 30 == 0  # this means it also divides by 5
@@ -823,7 +870,7 @@ class Configuration(Base):
         path_attrs = [
             "pv.pv_filename",
             "pv.pv_metadata_filename",
-            "satellite.satellite_zarr_path",
+            "satellite.satellite_zarr_path",k
             "hrvsatellite.hrvsatellite_zarr_path",
             "nwp.nwp_zarr_path",
             "gsp.gsp_zarr_path",

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -98,3 +98,27 @@ def test_config_git(configuration_filename):
     assert type(config.git.message) == str
     assert type(config.git.hash) == str
     assert type(config.git.committed_date) == datetime
+
+
+def test_incorrect_forecast_minutes():
+    """
+    Check a forecast length no divisible by time resolution causes error
+    """
+
+    configuration = Configuration()
+    configuration.input_data = configuration.input_data.set_all_to_defaults()
+    configuration.input_data.wind.forecast_minutes = 1111
+    with pytest.raises(Exception):
+        _ = Configuration(**configuration.dict())
+
+
+def test_incorrect_history_minutes():
+    """
+    Check a forecast length no divisible by time resolution causes error
+    """
+
+    configuration = Configuration()
+    configuration.input_data = configuration.input_data.set_all_to_defaults()
+    configuration.input_data.wind.history_minutes = 1111
+    with pytest.raises(Exception):
+        _ = Configuration(**configuration.dict())


### PR DESCRIPTION
# Pull Request

## Description

- Added validation of config parameters in Wind, PV, NWP to check that forecast_minutes % time_resolution_minutes == 0 and history_minutes % time_resolution_minutes == 0 (if this doesn't hold it can cause inconsistent shape in samples). Might be useful to add for other data sources as well, but I wasn't sure if there's caveats I wouldn't be aware of
- Added tests to check validation behaves as expected
- Fixed validator -> field_validator version issue along the way. Might be pushing the scope a bit, but felt weird to leave as was using new syntax anyway (see #318 )

Fixes #318 and [234 in PVNet](https://github.com/openclimatefix/PVNet/issues/234)

## How Has This Been Tested?
Added tests in test_config

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
