### PR TITLE
pv-site dynamic normalizing

### DIFF
--- a/ocf_datapipes/training/pvnet_site.py
+++ b/ocf_datapipes/training/pvnet_site.py
@@ -38,6 +38,8 @@ from ocf_datapipes.utils.utils import (
 xr.set_options(keep_attrs=True)
 logger = logging.getLogger("pvnet_site_datapipe")
 
+
+# TODO, these are used any more, but ive left them in here fo reference
 normalization_values = {
     2019: 3185.0,
     2020: 2678.0,
@@ -50,17 +52,8 @@ normalization_values = {
 
 def normalize_pv(x: xr.DataArray):
     """Normalize PV data"""
-    # This is after the data has been temporally sliced, so have the year
-    return x / normalization_values[2024]
+    return x / x.nominal_capacity_wp
 
-    year = x.time_utc.dt.year
-
-    # Add the effective_capacity_mwp to the dataset, indexed on the time_utc
-    return (
-        x / normalization_values[year]
-        if year in normalization_values
-        else x / normalization_values[2024]
-    )
 
 
 class DictDatasetIterDataPipe(IterDataPipe):

--- a/ocf_datapipes/training/pvnet_site.py
+++ b/ocf_datapipes/training/pvnet_site.py
@@ -55,7 +55,6 @@ def normalize_pv(x: xr.DataArray):
     return x / x.nominal_capacity_wp
 
 
-
 class DictDatasetIterDataPipe(IterDataPipe):
     """Create a dictionary of xr.Datasets from a dict of datapipes"""
 

--- a/ocf_datapipes/training/pvnet_site.py
+++ b/ocf_datapipes/training/pvnet_site.py
@@ -39,17 +39,6 @@ xr.set_options(keep_attrs=True)
 logger = logging.getLogger("pvnet_site_datapipe")
 
 
-# TODO, these are used any more, but ive left them in here fo reference
-normalization_values = {
-    2019: 3185.0,
-    2020: 2678.0,
-    2021: 3196.0,
-    2022: 3575.0,
-    2023: 3773.0,
-    2024: 3773.0,
-}
-
-
 def normalize_pv(x: xr.DataArray):
     """Normalize PV data"""
     return x / x.nominal_capacity_wp


### PR DESCRIPTION
# Pull Request

## Description

Upgrade from normalizing of pv with a dynaimc capacity number
before it was hard coded for the RUVNL site

This will help https://github.com/openclimatefix/india-forecast-app/issues/78

When retraining RUVNL, we might need to factor this in, or add a dynamic capacity data column

## How Has This Been Tested?

- Tested this by running the forecast ad india app locally
- CI tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
