### PR TITLE
extend gsp load history to 10 hours

### DIFF
--- a/ocf_datapipes/load/gsp/database.py
+++ b/ocf_datapipes/load/gsp/database.py
@@ -35,7 +35,7 @@ class OpenGSPFromDatabaseIterDataPipe(IterDataPipe):
 
     def __init__(
         self,
-        history_minutes: int = 90,
+        history_minutes: int = 600,
         interpolate_minutes: int = 60,
         load_extra_minutes: int = 60,
         national_only: bool = False,

--- a/tests/load/gsp/test_gsp_live.py
+++ b/tests/load/gsp/test_gsp_live.py
@@ -17,10 +17,10 @@ def test_get_gsp_power_from_database(gsp_yields, db_session):
     """Get GSP power from database"""
 
     gsp_power, gsp_nominal_capacity, gsp_effective_capacity = get_gsp_power_from_database(
-        history_duration=timedelta(hours=1), interpolate_minutes=30, load_extra_minutes=0
+        history_duration=timedelta(hours=10), interpolate_minutes=30, load_extra_minutes=0
     )
 
-    assert len(gsp_power) == 3  # 1 hours at 30 mins + 1
+    assert len(gsp_power) == 21  # 1 hours at 30 mins + 1
     assert len(gsp_power.columns) == 5
     assert gsp_power.columns[0] == 1
     assert (

--- a/tests/load/gsp/test_gsp_live.py
+++ b/tests/load/gsp/test_gsp_live.py
@@ -20,7 +20,7 @@ def test_get_gsp_power_from_database(gsp_yields, db_session):
         history_duration=timedelta(hours=10), interpolate_minutes=30, load_extra_minutes=0
     )
 
-    assert len(gsp_power) == 21  # 1 hours at 30 mins + 1
+    assert len(gsp_power) == 21  # 10 hours at 30 mins + 1
     assert len(gsp_power.columns) == 5
     assert gsp_power.columns[0] == 1
     assert (


### PR DESCRIPTION
Patch to allow PVNet to use older PVLive GSP data.

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
