### PR TITLE
Remove MetNet references from documentation (Issue #352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Modules have their own README's as well to go into further detail. This is part 
     ├── training/
     │   ├── common.py
     │   ├── example/
-    │   ├── metnet/
     │   ├── pseudo_irradience.py
     │   ├── pvnet.py
     │   ├── pvnet_site.py

--- a/ocf_datapipes/transform/xarray/README.md
+++ b/ocf_datapipes/transform/xarray/README.md
@@ -7,6 +7,4 @@ below.
 
 ## DataPipes that return non-Xarray objects
 
-- `metnet_preprocessor` returns a numpy array of the processed Xarray inputs following the description in the MetNet
-  2021 paper.
 - `find_contiguous_t0_time_periods` returns pandas DataFrames that contains the contiguous time periods


### PR DESCRIPTION
# Pull Request

## Description
This PR removes remaining MetNet references from the documentation to align with PR #346 which previously removed the MetNet features. This cleanup ensures documentation accurately reflects the current state of the codebase.

Changes made:
1. Removed `metnet/` from the directory tree in `README.md`
2. Removed `metnet_preprocessor` reference from `ocf_datapipes/transform/xarray/README.md`

Motivation: Keep documentation in sync with codebase changes, preventing confusion for new contributors.

Fixes #352

## How Has This Been Tested?
- [x] Yes
The changes are documentation-only. I have verified that:
1. All MetNet references have been removed from the specified files
2. No other documentation was accidentally modified
3. Performed a grep search to confirm no other MetNet references remain

## If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?
- [x] Yes
Not applicable as these are documentation-only changes.

## Checklist:
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
   (N/A - documentation only changes)